### PR TITLE
fix test coverage

### DIFF
--- a/test/storage/object/delete.test.js
+++ b/test/storage/object/delete.test.js
@@ -12,8 +12,7 @@
 import assert from 'node:assert';
 import esmock from 'esmock';
 import { mockClient } from 'aws-sdk-client-mock';
-import { DeleteObjectCommand, ListObjectsV2Command, S3Client } from '@aws-sdk/client-s3';
-import { getSignedUrl } from '@aws-sdk/s3-request-presigner';
+import { ListObjectsV2Command, S3Client } from '@aws-sdk/client-s3';
 
 const s3Mock = mockClient(S3Client);
 
@@ -252,11 +251,6 @@ describe('Object delete', () => {
             getSignedUrl: mockSignedUrl,
           }
         },
-        {
-          import: {
-            fetch: async () => ({ status: 200 }),
-          }
-        }
       );
       s3Mock.on(ListObjectsV2Command).resolves({ Contents: [{ Key: 'foo/bar.html' }] });
       const resp = await deleteObjects(env, daCtx, {});
@@ -287,11 +281,6 @@ describe('Object delete', () => {
             getSignedUrl: mockSignedUrl,
           }
         },
-        {
-          import: {
-            fetch: async () => ({ status: 200 }),
-          }
-        }
       );
       s3Mock.on(ListObjectsV2Command).resolves({ Contents: [{ Key: 'foo/bar.html' }], NextContinuationToken: 'token' });
       const resp = await deleteObjects(env, daCtx, {});

--- a/test/utils/auth.test.js
+++ b/test/utils/auth.test.js
@@ -29,7 +29,17 @@ import {
 const {
   setUser,
   getUsers,
-} = await esmock('../../src/utils/auth.js', { jose, import: { fetch } });
+} = await esmock('../../src/utils/auth.js', { jose });
+
+async function withMockedFetch(act) {
+  const savedFetch = globalThis.fetch;
+  globalThis.fetch = fetch;
+  try {
+    await act();
+  } finally {
+    globalThis.fetch = savedFetch;
+  }
+}
 
 describe('DA auth', () => {
   describe('get user', async () => {
@@ -49,14 +59,18 @@ describe('DA auth', () => {
     });
 
     it('authorized if email matches', async () => {
-      const users = await getUsers(reqs.site, env);
-      assert.strictEqual(users[0].email, 'aparker@geometrixx.info');
+      await withMockedFetch(async () => {
+        const users = await getUsers(reqs.site, env);
+        assert.strictEqual(users[0].email, 'aparker@geometrixx.info');
+      });
     });
 
     it('authorized with user if email matches and anonymous if present', async () => {
-      const users = await getUsers(reqs.siteMulti, env);
-      assert.strictEqual(users[0].email, 'anonymous')
-      assert.strictEqual(users[1].email, 'aparker@geometrixx.info');
+      await withMockedFetch(async () => {
+        const users = await getUsers(reqs.siteMulti, env);
+        assert.strictEqual(users[0].email, 'anonymous')
+        assert.strictEqual(users[1].email, 'aparker@geometrixx.info');
+      });
     });
 
     it('anonymous if ims fails', async () => {
@@ -71,8 +85,12 @@ describe('DA auth', () => {
         'Authorization': `Bearer aparker@geometrixx.info`,
       });
 
-      const userValStr = await setUser('aparker@geometrixx.info', 100, headers, env);
-      const userValue = JSON.parse(userValStr);
+      let userValue;
+
+      await withMockedFetch(async () => {
+        const userValStr = await setUser('aparker@geometrixx.info', 100, headers, env);
+        userValue = JSON.parse(userValStr);
+      });
 
       assert.strictEqual('aparker@geometrixx.info', userValue.email);
       assert.strictEqual('123', userValue.ident);


### PR DESCRIPTION
There is a bug with `c8` and `esmock` that breaks test coverage when mocking a global like:

```
await esmock('some-module.js', {}, {
  import: {
    fetch: mockFetch
  }
});
```

Instead, we should use:

```
async function withMockedFetch(act) {
  const savedFetch = globalThis.fetch;
  globalThis.fetch = fetch;
  try {
    await act();
  } finally {
    globalThis.fetch = savedFetch;
  }
}
```