### PR TITLE
fix: get handler returns undefined

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -51,6 +51,8 @@ export default {
         respObj = unknownHandler();
     }
 
+    if (!respObj) return daResp({ status: 404 });
+
     return daResp(respObj, daCtx);
   },
 };

--- a/test/handlers/get.test.js
+++ b/test/handlers/get.test.js
@@ -14,6 +14,16 @@ import assert from 'assert';
 import getHandler from '../../src/handlers/get.js';
 
 describe('Get Route', () => {
+  it('Test root', async () => {
+    const env = { };
+    const daCtx = {
+      path: '/',
+    };
+
+    const resp = await getHandler({ env, daCtx });
+    assert.strictEqual(resp, undefined);
+  });
+
   it('Test logout', async () => {
     const deleteCalled = [];
     const DA_AUTH = {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -42,4 +42,9 @@ describe('fetch', () => {
     const resp = await hnd.fetch({ method: 'GET' }, {});
     assert.strictEqual(resp.status, 403);
   });
+
+  it('return 404 for unknown get route', async () => {
+    const resp = await handler.fetch({ method: 'GET', url: 'http://www.example.com/' }, {});
+    assert.strictEqual(resp.status, 404);
+  });
 });


### PR DESCRIPTION
Error seen in the logs - lots of `500` with:

```
Cannot destructure property 'status' of 'undefined' as it is undefined.
```

for request: https://admin.da.live/ - or any of the unknown path.