### PR TITLE
fix: gzip encoded - force deflate

### DIFF
--- a/src/storage/object/get.js
+++ b/src/storage/object/get.js
@@ -30,7 +30,20 @@ export default async function getObject(env, { bucket, org, key }, head = false)
   const input = buildInput({ bucket, org, key });
   if (!head) {
     try {
+      client.middlewareStack.add(
+        (next) => (args) => {
+          // eslint-disable-next-line no-param-reassign
+          args.request.headers['Accept-Encoding'] = 'deflate';
+          return next(args);
+        },
+        {
+          step: 'build',
+          name: 'addAcceptEncodingMetadataMiddleware',
+        },
+      );
+
       const resp = await client.send(new GetObjectCommand(input));
+
       return {
         body: resp.Body,
         status: resp.$metadata.httpStatusCode,


### PR DESCRIPTION
This PR is a part of the fix for wrongly encoded files in R2:

During the bucket migration (from @auniverseaway to Franklin-dev) and for an unknown reason (wrong cache headers ?), some documents got wrongly encoded in the destination bucket - documents are gzip encoded with the source content type.

This cause a weird issue: not sure what happens in production, but when running locally, the worker hangs forever when reading the S3 client response body and is then completely unreachable - it has to be reloaded. I assume in prod, the request just times out. Consequence: empty page in authoring and content is never written to the file.

This PR addresses the GET problem. But it is not enough because the write crashes then (`Failed to update document Error: 411 - Length Required` in da-collab). Probably a similar trick could be found.

But I will not investigate further. I'll just make a console.warn to detect the corrupted documents and from time to time, run a script to clean up the few remaining corrupted files (script here: https://github.com/kptdobe/da-magic/blob/main/encoding/fix-s3-document-encoding.sh). 