### PR TITLE
fix: do not respond a 404 on error

### DIFF
--- a/src/storage/object/get.js
+++ b/src/storage/object/get.js
@@ -53,7 +53,11 @@ export default async function getObject(env, { bucket, org, key }, head = false)
         etag: resp.ETag,
       };
     } catch (e) {
-      return { body: '', status: e.$metadata?.httpStatusCode || 404, contentLength: 0 };
+      if (!e.$metadata?.httpStatusCode) {
+        // eslint-disable-next-line no-console
+        console.error('Error getting object without httpStatusCode', e);
+      }
+      return { body: '', status: e.$metadata?.httpStatusCode || 500, contentLength: 0 };
     }
   }
   const url = await getSignedUrl(client, new HeadObjectCommand(input), { expiresIn: 3600 });


### PR DESCRIPTION
I've found out that some documents are emptied when da-admin returns a 404. 
This is a very rare case. In the logs, I clearly a sequence:
- HEAD request to /source/doc.html: 200
- 2s later GET request to /source/doc.html: 404
- da-collab treats the 404 as `null` (i.e. "empty"): https://github.com/adobe/da-collab/blob/main/src/shareddoc.js#L209-L211

I cannot reproduce the problem but looking at the code, only option is that the S3 get command fails AND does not have a `httpStatusCode`. Probably micro temporary glitch somewhere. In any case, I think this is wrong to respond a 404 in the case, it should an error like 500.

I am also adding a console log for this exact specific case to trace it later.

I have tested the fix together with collab and this stop emptying the document.