### PR TITLE
fix: error when copying a file that exists

### DIFF
--- a/src/storage/object/copy.js
+++ b/src/storage/object/copy.js
@@ -90,6 +90,7 @@ export const copyFile = async (config, env, daCtx, sourceKey, details, isRename)
           { bucket: daCtx.bucket, org: daCtx.org, key: sourceKey },
         );
         return /* await */ putObjectWithVersion(env, daCtx, {
+          bucket: daCtx.bucket,
           org: daCtx.org,
           key: Key,
           body: original.body,

--- a/test/storage/object/copy.test.js
+++ b/test/storage/object/copy.test.js
@@ -450,6 +450,7 @@ describe('Object copy', () => {
       assert.strictEqual(puwv.length, 1);
       assert.strictEqual(puwv[0].c, daCtx);
       assert.strictEqual(puwv[0].e, env);
+      assert.strictEqual(puwv[0].u.bucket, 'mybucket');
       assert.strictEqual(puwv[0].u.body, 'original body');
       assert.strictEqual(puwv[0].u.contentLength, 42);
       assert.strictEqual(puwv[0].u.key, 'xdst/abc/def.html');


### PR DESCRIPTION
Saw this (recurrent) error in the logs when doing a POST to /copy:

```
Fail to put version
Error: No value provided for input HTTP label: Bucket.
```

Root cause analysis - The bug only occurred in the specific scenario where:
- A copy operation is attempted
- A file already exists at the destination (triggering the 412 path)
- The fallback to `putObjectWithVersion` was executed