### PR TITLE
fix: CopySource needs to be encoded

### DIFF
--- a/src/storage/object/copy.js
+++ b/src/storage/object/copy.js
@@ -46,16 +46,10 @@ export const copyFile = async (config, env, daCtx, sourceKey, details, isRename)
     return { $metadata: { httpStatusCode: 404 } };
   }
 
-  // URL-encode the key parts while preserving slashes for S3 folder structure
-  const encodedKey = sourceKey
-    .split('/')
-    .map((segment) => encodeURIComponent(segment))
-    .join('/');
-
   const input = {
     Bucket: daCtx.bucket,
     Key: `${daCtx.org}/${Key}`,
-    CopySource: `${daCtx.bucket}/${daCtx.org}/${encodedKey}`,
+    CopySource: `${daCtx.bucket}/${daCtx.org}/${encodeURI(sourceKey)}`,
     ContentType: source?.contentType || 'application/octet-stream',
   };
 

--- a/test/storage/object/copy.test.js
+++ b/test/storage/object/copy.test.js
@@ -506,7 +506,7 @@ describe('Object copy', () => {
       // Test file with commas, equals signs, and spaces
       const resp1 = await copyFile({}, env, daCtx, 'mysrc/icon=gift-box, style=two-toned.svg', details, false);
       assert.strictEqual(resp1.constructor.name, 'CopyObjectCommand');
-      assert.strictEqual(resp1.input.CopySource, 'root-bucket/myorg/mysrc/icon%3Dgift-box%2C%20style%3Dtwo-toned.svg');
+      assert.strictEqual(resp1.input.CopySource, 'root-bucket/myorg/mysrc/icon=gift-box,%20style=two-toned.svg');
       assert.strictEqual(resp1.input.Key, 'myorg/mydst/icon=gift-box, style=two-toned.svg');
 
       // Test file with spaces


### PR DESCRIPTION
Customer reported they cannot delete some folders, even though they are empty.

Root cause analysis: 

1. even if they appear empty, they still contain hidden folders with images of the deleted documents (would be great to delete them too - but different story)
2. some of those images have name like `boost%20saver_img1.jpg` or `icon=gift-box,%20style=two-toned.svg`
3. when running the copy, the command fails with a "not found": the command requires CopySource to be encoded