### PR TITLE
fix: stalled response

### DIFF
--- a/src/storage/utils/object.js
+++ b/src/storage/utils/object.js
@@ -30,9 +30,10 @@ export async function notifyCollab(api, url, env) {
   if (env.COLLAB_SHARED_SECRET) {
     headers.authorization = `token ${env.COLLAB_SHARED_SECRET}`;
   }
-  await env.dacollab.fetch(invURL, {
+  const resp = await env.dacollab.fetch(invURL, {
     // TODO: use POST for state changing operations
     // method: 'POST',
     headers,
   });
+  resp.body.cancel();
 }

--- a/test/integration/conditional-e2e.test.js
+++ b/test/integration/conditional-e2e.test.js
@@ -110,7 +110,7 @@ describe('Conditional Headers End-to-End', () => {
     const env = {
       AEM_BUCKET_NAME: 'test-bucket',
       dacollab: {
-        fetch: async () => ({ status: 200 }),
+        fetch: async () => ({ status: 200, body: { cancel: () => {} } }),
       },
     };
     const resp = await handler.default.fetch(req, env);

--- a/test/routes/source.test.js
+++ b/test/routes/source.test.js
@@ -19,7 +19,10 @@ describe('Source Route', () => {
   it('Test invalidate using service binding', async () => {
     const sb_callbacks = [];
     const dacollab = {
-      fetch: async (url) => sb_callbacks.push(url),
+      fetch: async (url) => {
+        sb_callbacks.push(url);
+        return { body: { cancel: () => {} } };
+      },
     };
     const env = {
       dacollab,

--- a/test/storage/object/copy.test.js
+++ b/test/storage/object/copy.test.js
@@ -343,7 +343,10 @@ describe('Object copy', () => {
       const collabCalled = [];
       const env = {
         dacollab: {
-          fetch: (x) => { collabCalled.push(x); },
+          fetch: (x) => {
+            collabCalled.push(x);
+            return { body: { cancel: () => {} } };
+          },
         },
       };
       const daCtx = {
@@ -569,7 +572,10 @@ describe('Object copy', () => {
       const collabCalled = [];
       const env = {
         dacollab: {
-          fetch: (x) => { collabCalled.push(x); },
+          fetch: (x) => {
+            collabCalled.push(x);
+            return { body: { cancel: () => {} } };
+          },
         },
       };
       const daCtx = { bucket: 'mybucket', org: 'xorg' };
@@ -631,7 +637,10 @@ describe('Object copy', () => {
       const collabCalled = [];
       const env = {
         dacollab: {
-          fetch: (x) => { collabCalled.push(x); },
+          fetch: (x) => {
+            collabCalled.push(x);
+            return { body: { cancel: () => {} } };
+          },
         },
       };
       const daCtx = { bucket: 'test-bucket', org: 'qqqorg', origin: 'http://qqq' };
@@ -680,7 +689,7 @@ describe('Object copy', () => {
         return null;
       };
 
-      const env = { dacollab: { fetch: () => {} } };
+      const env = { dacollab: { fetch: () => ({ body: { cancel: () => {} } }) } };
       const ctx = {
         bucket: 'root-bucket',
         org: 'foo',
@@ -713,7 +722,7 @@ describe('Object copy', () => {
             DA_JOBS[key] = value;
           },
         },
-        dacollab: { fetch: () => {} },
+        dacollab: { fetch: () => ({ body: { cancel: () => {} } }) },
       };
       s3Mock.on(ListObjectsV2Command)
         .resolves({
@@ -797,7 +806,7 @@ describe('Object copy', () => {
             return DA_JOBS[key];
           },
         },
-        dacollab: { fetch: () => {} },
+        dacollab: { fetch: () => ({ body: { cancel: () => {} } }) },
       };
 
       // Mock getObject to return content type for HEAD requests
@@ -858,7 +867,7 @@ describe('Object copy', () => {
             delete DA_JOBS[key];
           },
         },
-        dacollab: { fetch: () => {} },
+        dacollab: { fetch: () => ({ body: { cancel: () => {} } }) },
       };
 
       // Mock getObject to return content type for HEAD requests

--- a/test/storage/object/delete.test.js
+++ b/test/storage/object/delete.test.js
@@ -25,7 +25,12 @@ describe('Object delete', () => {
   describe('single context', () => {
     it('Delete a file', async () => {
       const collabCalled = [];
-      const dacollab = { fetch: (u) => collabCalled.push(u) };
+      const dacollab = {
+        fetch: (u) => {
+          collabCalled.push(u);
+          return { body: { cancel: () => {} } };
+        },
+      };
 
       const client = {};
       const env = { dacollab };
@@ -227,8 +232,7 @@ describe('Object delete', () => {
       };
       const env = {
         dacollab: {
-          fetch: () => {
-          },
+          fetch: () => ({ body: { cancel: () => {} } }),
         },
       };
       const mockPostObjectVersion = async () => ({ status: 201 });
@@ -257,8 +261,7 @@ describe('Object delete', () => {
       };
       const env = {
         dacollab: {
-          fetch: () => {
-          },
+          fetch: () => ({ body: { cancel: () => {} } }),
         },
       };
       const mockPostObjectVersion = async () => ({ status: 201 });

--- a/test/storage/utils/object.test.js
+++ b/test/storage/utils/object.test.js
@@ -21,6 +21,7 @@ describe('Storage Object Utils tests', () => {
       fetch: async (url) => {
         console.log(`invalidate called with ${url}`);
         called.push(url);
+        return { body: { cancel: () => {} } };
       },
     };
     const env = { dacollab };
@@ -53,6 +54,7 @@ describe('Storage Object Utils tests', () => {
           console.log(`invalidate called with ${url}`);
           assert.strictEqual(opts.headers.authorization, 'token example-secret');
           called.push(url);
+          return { body: { cancel: () => {} } };
         },
       },
       COLLAB_SHARED_SECRET: 'example-secret',


### PR DESCRIPTION
In the logs, we can observe a frequent warning for `POST` requests on `/source` (1.7k entries in the last 7 days):

```
A stalled HTTP response was canceled to prevent deadlock. This can happen when a Worker calls fetch() or cache.match() several times without reading the bodies of the returned Response objects. There is a limit on the number of concurrent HTTP requests that can be in-flight at one time. Normally, additional requests made beyond that limit are delayed until previous responses complete. However, because the Worker did not read the responses, they would never complete. Therefore, to prevent deadlock, the oldest response was canceled. To avoid this warning, make sure to either read the body of every HTTP Response or call response.body.cancel() to cancel a response that you don't plan to read from.
```

Just warnings from the worker, no error.