### PR TITLE
fix: no exception if no destination provided

### DIFF
--- a/src/helpers/copy.js
+++ b/src/helpers/copy.js
@@ -9,10 +9,16 @@
  * OF ANY KIND, either express or implied. See the License for the specific language
  * governing permissions and limitations under the License.
  */
+const NO_DEST_ERROR = {
+  body: JSON.stringify({ error: 'No destination provided.' }),
+  status: 400,
+};
+
 export default async function copyHelper(req, daCtx) {
   const formData = await req.formData();
   if (!formData) return {};
   const fullDest = formData.get('destination');
+  if (!fullDest) return { error: NO_DEST_ERROR };
   const continuationToken = formData.get('continuation-token');
   const lower = fullDest.slice(1).toLowerCase();
   const sanitized = lower.endsWith('/') ? lower.slice(0, -1) : lower;

--- a/src/routes/copy.js
+++ b/src/routes/copy.js
@@ -15,6 +15,7 @@ import { hasPermission } from '../utils/auth.js';
 
 export default async function copyHandler({ req, env, daCtx }) {
   const details = await copyHelper(req, daCtx);
+  if (details.error) return details.error;
   if (!hasPermission(daCtx, details.source, 'read')
     || !hasPermission(daCtx, details.destination, 'write')) return { status: 403 };
   return copyObject(env, daCtx, details, false);

--- a/test/routes/copy.test.js
+++ b/test/routes/copy.test.js
@@ -69,4 +69,30 @@ describe('Copy Route', () => {
     assert.strictEqual('my/dest2.html', copyCalled[0].d.destination);
     assert.strictEqual(false, copyCalled[0].m);
   });
+
+  it('Test copyHandler - no destination provided', async () => {
+    const copyCalled = [];
+    const copyObject = (e, c, d, m) => {
+      copyCalled.push({
+        e, c, d, m,
+      });
+      return { status: 200 };
+    };
+
+    const copyHandler = await esmock('../../src/routes/copy.js', {
+      '../../src/storage/object/copy.js': {
+        default: copyObject,
+      },
+      '../../src/utils/auth.js': { hasPermission: () => true },
+    });
+
+    const formdata = new Map();
+    const req = {
+      formData: () => formdata,
+    };
+
+    const resp = await copyHandler({ req, env: {}, daCtx: { key: 'my/src.html' } });
+    assert.strictEqual(400, resp.status);
+    assert.strictEqual(copyCalled.length, 0);
+  });
 });


### PR DESCRIPTION
We saw a peak of `500`, someone trying to copy without providing a destination: `Cannot read properties of null (reading 'slice')`.

Just applied the same logic than in `move.js` to stay consistent.