### PR TITLE
feat: add special IMS org with full access

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -19,6 +19,7 @@ export interface Env {
   AEM_BUCKET_NAME: string;
   // shared secret used as authorization when invoking the collab service (eg for syncadmin)
   COLLAB_SHARED_SECRET: string;
+  DA_OPS_IMS_ORG: string;
 
   DA_AUTH: KVNamespace,
   DA_CONFIG: KVNamespace,

--- a/src/utils/auth.js
+++ b/src/utils/auth.js
@@ -238,6 +238,19 @@ export async function getAclCtx(env, org, users, key, api) {
     };
   }
 
+  if (env.DA_OPS_IMS_ORG) {
+    props.permissions.data.push({
+      path: 'CONFIG',
+      groups: env.DA_OPS_IMS_ORG,
+      actions: 'write',
+    });
+    props.permissions.data.push({
+      path: '/ + **',
+      groups: env.DA_OPS_IMS_ORG,
+      actions: 'write',
+    });
+  }
+
   const aclTrace = [];
   props.permissions.data.forEach(({ path, groups, actions }) => {
     if (!path || !groups) return;

--- a/test/utils/auth.test.js
+++ b/test/utils/auth.test.js
@@ -389,6 +389,33 @@ describe('DA auth', () => {
       assert(aclCtx.actionSet.has('read'));
       assert(!aclCtx.actionSet.has('write'));
     });
+
+    it('test DA_OPS_IMS_ORG permissions', async () => {
+      const opsOrg = 'MyOpsOrg';
+      const envOps = {
+        ...env2,
+        DA_OPS_IMS_ORG: opsOrg,
+      };
+
+      // User in the OPS ORG
+      const users = [{ orgs: [{ orgIdent: opsOrg }] }];
+      const aclCtx = await getAclCtx(envOps, 'test', users, '/', 'config');
+
+      // Should have write permission on CONFIG because of DA_OPS_IMS_ORG injection
+      assert(hasPermission({
+        users, org: 'test', aclCtx, key: '',
+      }, 'CONFIG', 'write', true));
+
+      // Should have write permission on / because of DA_OPS_IMS_ORG injection (path: '/ + **')
+      assert(hasPermission({
+        users, org: 'test', aclCtx, key: '',
+      }, '/', 'write'));
+
+      // Should have write permission on path because of DA_OPS_IMS_ORG injection (path: '/ + **')
+      assert(hasPermission({
+        users, org: 'test', aclCtx, key: '',
+      }, '/some/deep/path', 'write'));
+    });
   });
 
   describe('persmissions single sheet', () => {


### PR DESCRIPTION
As DA ops team, we need to be able to support customers with common ops tasks:
- update their config (typical scenario: someone excluded themselves from CONFIG editing)
- read / write their content (inspect their prod content)

Today, if they still can, we ask the customers to add an IMS org / our email address to their CONFIG to access their projects. Or we go directly to Cloudflare DA_CONFIG KV or R2 storage. This is a really cumbersome or error prone process.

This PR: transparently add one IMS org (configured via the `DA_OPS_IMS_ORG` env variable) to each customer config. Whoever is member of the IMS org get full access (config and content) to all projects via the UI. Much easier to debug and fix problems.
We only need to be careful with IMS org management.