### PR TITLE
fix(auth): make user identifier comparison case-insensitive

### DIFF
--- a/src/utils/auth.js
+++ b/src/utils/auth.js
@@ -186,7 +186,7 @@ function getIdents(user) {
     }
   }
 
-  return idents;
+  return idents.map((ident) => ident?.toLowerCase());
 }
 
 export function getUserActions(pathLookup, user, target) {
@@ -273,7 +273,8 @@ export async function getAclCtx(env, org, users, key, api) {
       effectivePath = effectivePath.slice(0, -1);
     }
 
-    groups.split(',').map((entry) => entry.trim()).filter((entry) => entry.length > 0).forEach((group) => {
+    groups.split(',').map((entry) => entry.trim()).filter((entry) => entry.length > 0).forEach((g) => {
+      const group = g.toLowerCase();
       if (!pathLookup.has(group)) pathLookup.set(group, []);
       const groupEntries = pathLookup.get(group);
       const effectiveActions = actions
@@ -322,7 +323,9 @@ export async function getAclCtx(env, org, users, key, api) {
   }
 
   // Expose the action trace or not?
-  actionTrace = users.every((u) => aclTrace.includes(u.email)) ? actionTrace : undefined;
+  actionTrace = users.every((u) => aclTrace.includes(u.email?.toLowerCase()))
+    ? actionTrace
+    : undefined;
 
   if (k === 'CONFIG' || api === 'versionsource') {
     actionSet.add('read');


### PR DESCRIPTION
## Description

Make user identification (email, IMS org and group) for ACL permissions case insensitive.

So for example, if a user used a different case in the permissions sheet to specify an email compared to how identifiers are registered in IMS comparison is done in a case-insensitive way.

Added extra tests as well, also around the case-insensitive behaviour of the ACLTRACE, which was partly in place already.

## Related Issue

Fixes: https://github.com/adobe/da-live/issues/421


## How Has This Been Tested?

New and existing unit tests.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [X] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
