### PR TITLE
fix(versionsource): surface version creation failures and fix streaming warning

### DIFF
--- a/src/storage/version/put.js
+++ b/src/storage/version/put.js
@@ -52,6 +52,9 @@ export async function putVersion(config, {
     const status = e.$metadata?.httpStatusCode || 500;
     // eslint-disable-next-line no-console
     if (status >= 500) console.error('Fail to put version', e);
+    // Cancel the body stream if it wasn't consumed (e.g. R2 rejected via 100-continue on 412).
+    // Without this, Cloudflare Workers logs "non-retryable streaming request" warnings.
+    if (Body?.cancel) Body.cancel();
     return { status };
   }
 }
@@ -181,6 +184,7 @@ export async function putObjectWithVersion(
 
   const pps = current.metadata?.preparsingstore || '0';
   let storeBody = !body && pps === '0';
+  let versionCreated = false;
   let Preparsingstore = storeBody ? Timestamp : pps;
   let Label = storeBody ? 'Collab Parse' : update.label;
 
@@ -219,6 +223,7 @@ export async function putObjectWithVersion(
     if (versionResp.status !== 200 && versionResp.status !== 412) {
       return { status: versionResp.status, metadata: { id: ID } };
     }
+    versionCreated = versionResp.status === 200;
   }
 
   const metadata = {
@@ -249,6 +254,7 @@ export async function putObjectWithVersion(
       status: resp.$metadata.httpStatusCode,
       metadata: { id: ID },
       etag: resp.ETag,
+      versionCreated,
     };
   } catch (e) {
     const status = e.$metadata?.httpStatusCode || 500;
@@ -282,7 +288,9 @@ export async function postObjectVersionWithLabel(label, env, daCtx) {
     bucket, org, key, body, contentLength, type: contentType, label,
   }, true);
 
-  return { status: resp.status === 200 ? 201 : resp.status };
+  if (resp.status !== 200) return { status: resp.status };
+  if (!resp.versionCreated) return { status: 500 };
+  return { status: 201 };
 }
 
 export async function postObjectVersion(req, env, daCtx) {

--- a/test/storage/version/put.test.js
+++ b/test/storage/version/put.test.js
@@ -2095,4 +2095,177 @@ describe('Version Put', () => {
       assert.strictEqual(sentCommands.length, 1);
     });
   });
+
+  it('putVersion cancels body stream when PUT is rejected', async () => {
+    let cancelled = false;
+    const mockBody = {
+      cancel: () => { cancelled = true; },
+    };
+
+    const mockS3Client = {
+      async send() {
+        const e = new Error('Precondition Failed');
+        e.$metadata = { httpStatusCode: 412 };
+        throw e;
+      },
+    };
+
+    const { putVersion } = await esmock('../../../src/storage/version/put.js', {
+      '../../../src/storage/utils/version.js': {
+        ifNoneMatch: () => mockS3Client,
+      },
+    });
+
+    const resp = await putVersion({}, { Body: mockBody });
+    assert.equal(412, resp.status);
+    assert.strictEqual(true, cancelled, 'Body.cancel() must be called to avoid non-retryable streaming warnings');
+  });
+
+  it('putVersion does not fail when Body has no cancel method', async () => {
+    const mockS3Client = {
+      async send() {
+        const e = new Error('error');
+        e.$metadata = { httpStatusCode: 412 };
+        throw e;
+      },
+    };
+
+    const { putVersion } = await esmock('../../../src/storage/version/put.js', {
+      '../../../src/storage/utils/version.js': {
+        ifNoneMatch: () => mockS3Client,
+      },
+    });
+
+    // Body is a plain string — no .cancel() method — must not throw
+    const resp = await putVersion({}, { Body: 'plain string body' });
+    assert.equal(412, resp.status);
+  });
+
+  it('putObjectWithVersion sets versionCreated true when version was written', async () => {
+    const mockGetObject = async () => ({
+      body: 'content',
+      contentType: 'text/html',
+      contentLength: 7,
+      metadata: { id: 'doc-id', version: 'ver-1' },
+      status: 200,
+    });
+
+    const mockS3Client = {
+      send: () => ({ $metadata: { httpStatusCode: 200 } }),
+    };
+
+    const { putObjectWithVersion } = await esmock('../../../src/storage/version/put.js', {
+      '../../../src/storage/object/get.js': { default: mockGetObject },
+      '../../../src/storage/utils/version.js': {
+        ifNoneMatch: () => mockS3Client,
+        ifMatch: () => mockS3Client,
+      },
+    });
+
+    const resp = await putObjectWithVersion({}, { org: 'o', ext: 'html', users: [] }, { org: 'o', key: 'a.html', body: 'new' }, true);
+    assert.equal(200, resp.status);
+    assert.strictEqual(true, resp.versionCreated);
+  });
+
+  it('putObjectWithVersion sets versionCreated false when version already existed (putVersion 412)', async () => {
+    const mockGetObject = async () => ({
+      body: 'content',
+      contentType: 'text/html',
+      contentLength: 7,
+      metadata: { id: 'doc-id', version: 'ver-1' },
+      status: 200,
+    });
+
+    const versionClient = {
+      send: () => {
+        const e = new Error('Already exists');
+        e.$metadata = { httpStatusCode: 412 };
+        throw e;
+      },
+    };
+    const mainClient = {
+      send: () => ({ $metadata: { httpStatusCode: 200 } }),
+    };
+
+    const { putObjectWithVersion } = await esmock('../../../src/storage/version/put.js', {
+      '../../../src/storage/object/get.js': { default: mockGetObject },
+      '../../../src/storage/utils/version.js': {
+        ifNoneMatch: () => versionClient,
+        ifMatch: () => mainClient,
+      },
+    });
+
+    const resp = await putObjectWithVersion({}, { org: 'o', ext: 'html', users: [] }, { org: 'o', key: 'a.html', body: 'new' }, true);
+    assert.equal(200, resp.status);
+    assert.strictEqual(false, resp.versionCreated);
+  });
+
+  it('postObjectVersion returns 500 when version was not created (putVersion 412)', async () => {
+    const req = { json: async () => ({ label: 'my-label' }) };
+    const env = {};
+    const ctx = {
+      bucket: 'mybucket', org: 'org123', key: 'doc.html', ext: 'html',
+    };
+
+    const mockGetObject = async () => ({
+      body: ReadableStream.from('doccontent'),
+      contentType: 'text/html',
+      contentLength: 10,
+      metadata: { id: 'doc-id', version: 'ver-1' },
+      status: 200,
+    });
+
+    const versionClient = {
+      send: () => {
+        const e = new Error('Already exists');
+        e.$metadata = { httpStatusCode: 412 };
+        throw e;
+      },
+    };
+    const mainClient = {
+      send: () => ({ $metadata: { httpStatusCode: 200 } }),
+    };
+
+    const { postObjectVersion } = await esmock('../../../src/storage/version/put.js', {
+      '../../../src/storage/object/get.js': { default: mockGetObject },
+      '../../../src/storage/utils/version.js': {
+        ifNoneMatch: () => versionClient,
+        ifMatch: () => mainClient,
+      },
+    });
+
+    const resp = await postObjectVersion(req, env, ctx);
+    assert.equal(500, resp.status);
+  });
+
+  it('postObjectVersion returns 201 when version is successfully created', async () => {
+    const req = { json: async () => ({ label: 'my-label' }) };
+    const env = {};
+    const ctx = {
+      bucket: 'mybucket', org: 'org123', key: 'doc.html', ext: 'html',
+    };
+
+    const mockGetObject = async () => ({
+      body: ReadableStream.from('doccontent'),
+      contentType: 'text/html',
+      contentLength: 10,
+      metadata: { id: 'doc-id', version: 'ver-1' },
+      status: 200,
+    });
+
+    const mockS3Client = {
+      send: () => ({ $metadata: { httpStatusCode: 200 } }),
+    };
+
+    const { postObjectVersion } = await esmock('../../../src/storage/version/put.js', {
+      '../../../src/storage/object/get.js': { default: mockGetObject },
+      '../../../src/storage/utils/version.js': {
+        ifNoneMatch: () => mockS3Client,
+        ifMatch: () => mockS3Client,
+      },
+    });
+
+    const resp = await postObjectVersion(req, env, ctx);
+    assert.equal(201, resp.status);
+  });
 });


### PR DESCRIPTION
Two related bugs in POST /versionsource:

1. Non-retryable streaming warning in Cloudflare Workers

When putVersion sends an HTML body (piped from an S3 GET response) to R2 using If-None-Match: *, R2 can reject the PUT via Expect: 100-continue before reading the body. The S3 GET response stream is then left open and unconsumed, causing Cloudflare Workers to log:
  "An error was encountered in a non-retryable streaming request."
Fix: cancel Body in putVersion's catch block so the underlying connection is properly closed.

2. POST /versionsource silently returns 201 when no version was created putVersion uses If-None-Match: * to write the version snapshot. When R2 returns 412 (version UUID already stored, or a false-positive during Worker cold starts under batch load), the code treated 412 as acceptable and continued to the main document PUT, ultimately returning 201. This made it impossible for callers to detect that no version was written.

The API contract for POST /versionsource is "create a version". If no version is created for any reason, the response must be an error.

Fix: track versionCreated in putObjectWithVersion and have postObjectVersionWithLabel return 500 when the version PUT did not produce a new snapshot. The main document PUT still runs on 412 (it bumps the version UUID), so a client retry will use a fresh UUID and succeed — matching observed behaviour where re-running the request on affected documents works correctly.