### PR TITLE
fix: guard against null body in notifyCollab to prevent move partial_failure

### DIFF
--- a/src/storage/utils/object.js
+++ b/src/storage/utils/object.js
@@ -35,5 +35,5 @@ export async function notifyCollab(api, url, env) {
     // method: 'POST',
     headers,
   });
-  resp.body.cancel();
+  resp.body?.cancel();
 }

--- a/test/storage/utils/object.test.js
+++ b/test/storage/utils/object.test.js
@@ -46,6 +46,22 @@ describe('Storage Object Utils tests', () => {
     assert.strictEqual(called.length, 0, 'should not have invalidated anything');
   });
 
+  it('does not throw when collab response has null body', async () => {
+    // Regression test: notifyCollab calls resp.body.cancel() unconditionally. When the collab
+    // service returns a response with no body (null), this throws TypeError: Cannot read
+    // properties of null (reading 'cancel'). In copyFile this fires in a finally block,
+    // which cancels the return value and causes the move to fail with partial_failure 500 —
+    // leaving the file duplicated at both source and destination.
+    const env = {
+      dacollab: {
+        fetch: async () => ({ body: null }),
+      },
+    };
+    await assert.doesNotReject(
+      notifyCollab('syncadmin', 'https://admin.da.live/source/a/b/c.html', env),
+    );
+  });
+
   it('Should invalidate (with shared secret', async () => {
     const called = [];
     const env = {


### PR DESCRIPTION
## Summary

- `notifyCollab` (used by `copyFile`) called `resp.body.cancel()` with no null guard
- When the collab service returns a bodyless response, this threw `TypeError: Cannot read properties of null (reading 'cancel')` inside the `finally` block of `copyFile`
- Because `finally` exceptions replace the return value, the successful S3 `CopyObjectCommand` result was discarded — `deleteObject` was never called, leaving files **duplicated** at both source and destination
- The move endpoint returned `partial_failure` 500 instead of 204

Fix: `resp.body?.cancel()` — one character, safe for all cases including undefined.

This bug was revealed by PR #266 (move error logging), which made previously silent `partial_failure` 500s visible in Cloudflare Worker logs.

## Test plan

- [x] New regression test: `does not throw when collab response has null body` in `test/storage/utils/object.test.js`
- [x] All existing `notifyCollab` tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)