### PR TITLE
fix: handle KV 414 error when IMS auth fragment leaks into org path

### DIFF
--- a/src/utils/auth.js
+++ b/src/utils/auth.js
@@ -238,7 +238,14 @@ export async function getAclCtx(env, org, users, key, api) {
     };
   }
 
-  const props = await env.DA_CONFIG?.get(org, { type: 'json' });
+  let props;
+  try {
+    props = await env.DA_CONFIG?.get(org, { type: 'json' });
+  } catch {
+    // KV rejects keys longer than 512 bytes (e.g. IMS auth fragments leaking into the URL path).
+    // Treat as no config found — deny all access rather than propagating a 500.
+    return { pathLookup, actionSet: new Set() };
+  }
 
   if (props && props[':type'] === 'sheet' && props[':sheetname'] === 'permissions') {
     // It's a single-sheet, move the data to the right place

--- a/test/utils/auth.test.js
+++ b/test/utils/auth.test.js
@@ -557,6 +557,26 @@ describe('DA auth', () => {
         users, org: 'test', aclCtx, key: '',
       }, '/some/deep/path', 'write'));
     });
+
+    it('returns empty action set when DA_CONFIG KV GET throws 414 key-too-long error', async () => {
+      // IMS auth redirect fragments (access_token=..., ld_hash=...) leak into the URL path,
+      // producing an org segment >512 bytes. KV rejects the lookup with a 414 error;
+      // without a guard this unhandled exception propagates to a 500 response.
+      const longOrg = 'a'.repeat(513);
+      const kv414Error = new Error(
+        `KV GET failed: 414 UTF-8 encoded length of ${longOrg.length} exceeds key length limit of 512.`,
+      );
+      const failEnv = {
+        DA_CONFIG: {
+          get: () => {
+            throw kv414Error;
+          },
+        },
+      };
+      const users = [{ email: 'user@example.com' }];
+      const aclCtx = await getAclCtx(failEnv, longOrg, users, '/test');
+      assert.strictEqual(aclCtx.actionSet.size, 0, 'oversized org name must produce empty action set, not throw');
+    });
   });
 
   describe('persmissions single sheet', () => {


### PR DESCRIPTION
## Problem

IMS OAuth redirect fragments leak into the admin API URL path on the client side. After a login redirect, the URL fragment (`#access_token=...` or `#ld_hash=...`) is incorrectly included when constructing the config endpoint URL, resulting in requests like:

```
GET https://admin.da.live/config/ccess_token=<jwt>&state=%7B%22jslibver%22%3A%22v2-v0.48.0%22...%7D&token_type=bearer&expires_in=86399998/
```

`getAclCtx()` passes the extracted org segment directly to `env.DA_CONFIG.get()` as a KV key. When that segment contains the full IMS token payload (~1986 bytes), Cloudflare KV rejects it:

```
Error computing context
Error: KV GET failed: 414 UTF-8 encoded length of 1986 exceeds key length limit of 512.
```

This unhandled exception propagated through `getDaCtx()` and was caught by the generic error handler in `index.js`, returning a **500** to the client.

Observed in production logs over the last 12h: multiple 500 responses tied to `RayID: 9f43e69cbfa5561f` and similar.

## Fix

Wrap the `DA_CONFIG.get(org)` call in `getAclCtx()` with a try/catch. On any KV error, return an empty `actionSet` so the existing `!authorized` check in `index.js` returns a clean **403** instead of a 500.

The root cause (client-side IMS fragment leaking into the URL) is a separate issue in da-website/da-collab; this fix makes the worker resilient to it.

## Test plan

- [x] New unit test: `returns empty action set when DA_CONFIG KV GET throws 414 key-too-long error` — confirms the fix handles the exact production error without throwing
- [x] Full test suite passes (369 tests)
- [x] ESLint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)