### PR TITLE
fix(copy): return 400 when /copy body is not form-encoded

### DIFF
--- a/src/helpers/copy.js
+++ b/src/helpers/copy.js
@@ -14,8 +14,18 @@ const NO_DEST_ERROR = {
   status: 400,
 };
 
+const BAD_CONTENT_TYPE_ERROR = {
+  body: JSON.stringify({ error: 'Invalid Content-Type. Expected multipart/form-data or application/x-www-form-urlencoded.' }),
+  status: 400,
+};
+
 export default async function copyHelper(req, daCtx) {
-  const formData = await req.formData();
+  let formData;
+  try {
+    formData = await req.formData();
+  } catch {
+    return { error: BAD_CONTENT_TYPE_ERROR };
+  }
   if (!formData) return {};
   const fullDest = formData.get('destination');
   if (!fullDest) return { error: NO_DEST_ERROR };

--- a/test/routes/copy.test.js
+++ b/test/routes/copy.test.js
@@ -70,6 +70,35 @@ describe('Copy Route', () => {
     assert.strictEqual(false, copyCalled[0].m);
   });
 
+  it('Test copyHandler returns 400 when request body is not form-encoded', async () => {
+    const copyCalled = [];
+    const copyObject = (e, c, d, m) => {
+      copyCalled.push({
+        e, c, d, m,
+      });
+      return { status: 200 };
+    };
+
+    const copyHandler = await esmock('../../src/routes/copy.js', {
+      '../../src/storage/object/copy.js': {
+        default: copyObject,
+      },
+      '../../src/utils/auth.js': { hasPermission: () => true },
+    });
+
+    const req = {
+      formData: () => {
+        throw new TypeError('Unrecognized Content-Type header value. FormData can only parse the following MIME types: multipart/form-data, application/x-www-form-urlencoded');
+      },
+    };
+
+    const resp = await copyHandler({ req, env: {}, daCtx: { key: 'my/src.html' } });
+    assert.strictEqual(resp.status, 400);
+    assert.strictEqual(copyCalled.length, 0);
+    const body = JSON.parse(resp.body);
+    assert.match(body.error, /Content-Type/i);
+  });
+
   it('Test copyHandler - no destination provided', async () => {
     const copyCalled = [];
     const copyObject = (e, c, d, m) => {


### PR DESCRIPTION
## Why

Today's da-admin daily log review (24h ending 2026-05-07) surfaced **5 production POST 500s** on `/copy/scdemos/demo[/about-us.html]`, every one with the same unhandled exception:

```
TypeError: Unrecognized Content-Type header value. FormData can only parse the following MIME types: multipart/form-data, application/x-www-form-urlencoded
```

Coralogix breakdown (filter `$d.ScriptName == 'da-admin' AND $d.Outcome == 'exception'`):

| ExceptionName | ExceptionMessage | hits |
|---|---|---|
| TypeError | Unrecognized Content-Type header value. FormData can only parse the following MIME types: multipart/form-data, application/x-www-form-urlencoded | 5 |

Root cause: `src/helpers/copy.js` calls `await req.formData()` unguarded. Cloudflare workers' `FormData` parser throws synchronously on unsupported MIME types, the throw bubbles into the worker runtime, and the client gets a 500 instead of a 4xx.

## What

- Wrap `req.formData()` in `try/catch` and return the existing `{ error }` shape with status 400 + a clear message.
- Add a unit test that simulates the production `TypeError` and asserts the handler returns `400` with a `Content-Type` error message. Test fails on `main`, passes after the fix.

```js
const BAD_CONTENT_TYPE_ERROR = {
  body: JSON.stringify({ error: 'Invalid Content-Type. Expected multipart/form-data or application/x-www-form-urlencoded.' }),
  status: 400,
};

let formData;
try {
  formData = await req.formData();
} catch {
  return { error: BAD_CONTENT_TYPE_ERROR };
}
```

The route layer (`src/routes/copy.js`) already does `if (details.error) return details.error;`, so no route changes are needed.

## Verification

```
$ npm test -- --grep "Copy Route"
  Copy Route
    ✔ Test copyHandler with permissions
    ✔ Test copyHandler returns 400 when request body is not form-encoded
    ✔ Test copyHandler - no destination provided

  3 passing
```

`copy.js` helper coverage: 100% statements, 81.81% branches.

`npx eslint src/helpers/copy.js test/routes/copy.test.js` → clean.

## Out of scope

The same unguarded `req.formData()` pattern exists in `move.js`, `source.js`, `delete.js`, `rename.js`, `kv/put.js`. None of them surfaced in today's logs, so this PR scopes to `/copy` only — fix the rest lazily as they appear in future daily reviews.