### PR TITLE
feat: add DA_OPS_IMS_BOT_EMAIL escape hatch for bot write access

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -20,6 +20,7 @@ export interface Env {
   // shared secret used as authorization when invoking the collab service (eg for syncadmin)
   COLLAB_SHARED_SECRET: string;
   DA_OPS_IMS_ORG: string;
+  DA_OPS_IMS_BOT_EMAIL: string;
 
   DA_AUTH: KVNamespace,
   DA_CONFIG: KVNamespace,

--- a/src/utils/auth.js
+++ b/src/utils/auth.js
@@ -272,6 +272,19 @@ export async function getAclCtx(env, org, users, key, api) {
     });
   }
 
+  if (env.DA_OPS_IMS_BOT_EMAIL) {
+    props.permissions.data.push({
+      path: 'CONFIG',
+      groups: env.DA_OPS_IMS_BOT_EMAIL,
+      actions: 'write',
+    });
+    props.permissions.data.push({
+      path: '/ + **',
+      groups: env.DA_OPS_IMS_BOT_EMAIL,
+      actions: 'write',
+    });
+  }
+
   const aclTrace = [];
   props.permissions.data.forEach(({ path, groups, actions }) => {
     if (!path || !groups) return;

--- a/test/utils/auth.test.js
+++ b/test/utils/auth.test.js
@@ -558,6 +558,45 @@ describe('DA auth', () => {
       }, '/some/deep/path', 'write'));
     });
 
+    it('test DA_OPS_IMS_BOT_EMAIL permissions', async () => {
+      const botEmail = 'da-ops-bot@adobe.com';
+      const envBot = {
+        ...env2,
+        DA_OPS_IMS_BOT_EMAIL: botEmail,
+      };
+
+      // Bot user identified solely by email — no orgs membership at all.
+      // This is the substantive difference from the DA_OPS_IMS_ORG test:
+      // the bearer is matched on email, independent of IMS org membership.
+      const users = [{ email: botEmail, orgs: [] }];
+      const aclCtx = await getAclCtx(envBot, 'test', users, '/', 'config');
+
+      // Should have write permission on CONFIG because of DA_OPS_IMS_BOT_EMAIL injection
+      assert(hasPermission({
+        users, org: 'test', aclCtx, key: '',
+      }, 'CONFIG', 'write', true));
+
+      // Should have write permission on / because of DA_OPS_IMS_BOT_EMAIL injection
+      // (path: '/ + **')
+      assert(hasPermission({
+        users, org: 'test', aclCtx, key: '',
+      }, '/', 'write'));
+
+      // Should have write permission on path because of DA_OPS_IMS_BOT_EMAIL injection
+      // (path: '/ + **')
+      assert(hasPermission({
+        users, org: 'test', aclCtx, key: '',
+      }, '/some/deep/path', 'write'));
+
+      // A different email must NOT inherit bot permissions — the rule matches
+      // on the specific email, not on "any user when DA_OPS_IMS_BOT_EMAIL is set".
+      const otherUsers = [{ email: 'not-the-bot@adobe.com', orgs: [] }];
+      const otherCtx = await getAclCtx(envBot, 'test', otherUsers, '/', 'config');
+      assert(!hasPermission({
+        users: otherUsers, org: 'test', aclCtx: otherCtx, key: '',
+      }, '/', 'write'));
+    });
+
     it('returns empty action set when DA_CONFIG KV GET throws 414 key-too-long error', async () => {
       // IMS auth redirect fragments (access_token=..., ld_hash=...) leak into the URL path,
       // producing an org segment >512 bytes. KV rejects the lookup with a 414 error;


### PR DESCRIPTION
## Summary

Adds `DA_OPS_IMS_BOT_EMAIL`, a Worker env variable that grants its bearer the same full-write ops escape hatch as the existing `DA_OPS_IMS_ORG` (introduced in #233), but matched against the user's IMS profile email instead of an IMS org identifier. Use case: scoping ops write access to one bot identity rather than every member of an IMS org.

## Changes

- `src/utils/auth.js` — inside `getAclCtx`, mirror the existing `if (env.DA_OPS_IMS_ORG)` block with a structurally identical block keyed on `env.DA_OPS_IMS_BOT_EMAIL`. Injects two ACL rows (`write` on `CONFIG`, `write` on `/ + **`).
- `src/index.d.ts` — add `DA_OPS_IMS_BOT_EMAIL: string;` to the `Env` interface.
- `test/utils/auth.test.js` — add `'test DA_OPS_IMS_BOT_EMAIL permissions'` mirroring the existing `DA_OPS_IMS_ORG` test, plus a negative assertion that a non-matching email is denied.

## Behavior

Both env vars are independent and additive. Either, both, or neither may be set.

| `DA_OPS_IMS_ORG` | `DA_OPS_IMS_BOT_EMAIL` | Result |
|---|---|---|
| no | no | unchanged from today |
| yes | no | unchanged from today (existing escape hatch) |
| no | yes | users with matching email get full write |
| yes | yes | union — users matching either get full write |

Matching is case-insensitive: `getIdents` lowercases `user.email` and the rule-build loop lowercases each `groups` token, so no normalization is needed at injection.

## Notes for operators

The value must be a single email address. Comma-separated multi-value is not validated and would silently grant access to multiple identities through the downstream `groups.split(',')` parser — out of scope for this change; if multi-bot is needed later, add it explicitly.

## Test Plan

- [x] `npm test` — 391 passing, 0 failing
- [x] `npm run lint` — clean
- [x] New test fails before the implementation commit (TDD red), passes after (green)
- [x] Existing `DA_OPS_IMS_ORG` test still passes (no regression on the precedent)

🤖 Generated with [Claude Code](https://claude.com/claude-code)