### PR TITLE
fix(version): log diagnostics on POST /versionsource silent 500

### DIFF
--- a/src/storage/version/put.js
+++ b/src/storage/version/put.js
@@ -314,7 +314,9 @@ export async function putObjectWithVersion(
 }
 
 export async function postObjectVersionWithLabel(label, env, daCtx) {
-  const { body, contentLength, contentType } = await getObject(env, daCtx);
+  const {
+    body, contentLength, contentType, status: currentStatus,
+  } = await getObject(env, daCtx);
   // Buffer the ReadableStream so the body survives retries inside putObjectWithVersion.
   // A ReadableStream can only be consumed once; ArrayBuffer can be reused freely.
   const bodyBuffer = body instanceof ReadableStream ? await new Response(body).arrayBuffer() : body;
@@ -325,7 +327,18 @@ export async function postObjectVersionWithLabel(label, env, daCtx) {
   }, true);
 
   if (resp.status !== 200) return { status: resp.status };
-  if (!resp.versionCreated) return { status: 500, error: 'Version was not created' };
+  if (!resp.versionCreated) {
+    // Diagnostic: the silent-500 path lands here when the source object's contentType
+    // is not html/json (e.g. legacy imports with missing ContentType metadata) so
+    // shouldCreateVersion gates out and no version is written.
+    // eslint-disable-next-line no-console
+    console.error('Failed to version (no version created)', {
+      contentType,
+      hadLabel: label != null,
+      currentStatus,
+    });
+    return { status: 500, error: 'Version was not created' };
+  }
   return { status: 201 };
 }
 

--- a/test/storage/version/put.test.js
+++ b/test/storage/version/put.test.js
@@ -3162,6 +3162,68 @@ describe('Version Put', () => {
       assert.strictEqual(resp.status, 201, 'must return 201 when version already exists (concurrent 412)');
     });
 
+    it('logs diagnostics when versionCreated is false (silent 500 path)', async () => {
+      // Regression: legacy HTML imports can land in storage with no S3
+      // ContentType metadata. shouldCreateVersion(undefined) returns false ->
+      // shouldCreateVersionObject is false -> putObjectWithVersion returns
+      // { status: 200, versionCreated: false } -> postObjectVersionWithLabel
+      // returns a silent 500 with empty Cloudflare Logs (no console.error).
+      // The fix adds a single diagnostic log capturing contentType / hadLabel /
+      // currentStatus so the next daily review can confirm root cause.
+      const mockGetObject = async () => ({
+        body: 'doc content',
+        contentType: undefined,
+        contentLength: 200,
+        status: 200,
+        metadata: { id: 'doc-id', version: 'v1' },
+        etag: '"etag1"',
+      });
+
+      const mainClient = {
+        async send() { return { $metadata: { httpStatusCode: 200 } }; },
+      };
+      const versionClient = {
+        async send() { return { $metadata: { httpStatusCode: 200 } }; },
+      };
+
+      const { postObjectVersionWithLabel } = await esmock('../../../src/storage/version/put.js', {
+        '../../../src/storage/object/get.js': { default: mockGetObject },
+        '../../../src/storage/utils/version.js': {
+          ifNoneMatch: () => versionClient,
+          ifMatch: () => mainClient,
+        },
+        '../../../src/storage/version/audit.js': {
+          writeAuditEntry: async () => ({ status: 200 }),
+        },
+        '../../../src/storage/utils/config.js': { default: () => ({}) },
+      });
+
+      const daCtx = {
+        bucket: 'b', org: 'o', key: 'doc.html', ext: 'html', users: [],
+      };
+
+      const errors = [];
+      const origError = console.error;
+      console.error = (...args) => {
+        errors.push(args);
+      };
+      let resp;
+      try {
+        resp = await postObjectVersionWithLabel('My Label', {}, daCtx);
+      } finally {
+        console.error = origError;
+      }
+
+      assert.strictEqual(resp.status, 500);
+      assert.strictEqual(resp.error, 'Version was not created');
+      assert(errors.length > 0, 'silent-500 path must emit a console.error so Cloudflare Logs is non-empty');
+      const payload = errors[0].find((a) => a && typeof a === 'object');
+      assert(payload, 'log must include a structured diagnostic payload');
+      assert.strictEqual(payload.contentType, undefined, 'payload must record contentType (undefined when source metadata is missing)');
+      assert.strictEqual(payload.hadLabel, true, 'payload must record whether a label was supplied');
+      assert.strictEqual(payload.currentStatus, 200, 'payload must record the source-object status');
+    });
+
     it('returns 201 when version client body is a ReadableStream that would be disturbed by SDK retry', async () => {
       // Regression test: putVersion passes current.body (a ReadableStream from getObject) to
       // PutObjectCommand. The AWS SDK retries on network failures using the same stream — but a


### PR DESCRIPTION
## Summary

- Adds a single `console.error` in `postObjectVersionWithLabel` before the existing silent `return { status: 500, error: "Version was not created" }` branch, capturing `{ contentType, hadLabel, currentStatus }` so the failure shows up in Cloudflare Logs instead of arriving empty.
- No behavior change otherwise -- same 500 status, same error string returned to the caller.

## Why

We saw a cluster of `POST /versionsource` returning 500 with empty `Logs[]`, empty `Exceptions[]`, and `Outcome == ok`, concentrated on legacy-imported HTML pages. After #271 closed the 412-race silent-500, the only remaining path to that branch is `putObjectWithVersion` returning `{ status: 200, versionCreated: false }`, which requires `shouldCreateVersion(contentType)` to be false. For these legacy-imported HTML pages the S3 object metadata is missing `ContentType`, so `current.contentType` is `undefined` -> `createVersion=false` -> no version object is written -> silent 500.

Without instrumentation, the next log review cannot tell whether the cluster is contentType-missing, label-related, or a regression. This adds the cheapest possible diagnostic so the theory can be confirmed (or refuted) from logs alone -- no code archaeology, no client repro needed.

## Approach

- Failing test first: asserts `postObjectVersionWithLabel` emits a structured `console.error` with `contentType`, `hadLabel`, `currentStatus` when the source object has no `contentType`. Confirmed it failed on `main` before the implementation change.
- Implementation: destructure `status: currentStatus` from the outer `getObject` call and emit one `console.error` inside the `!resp.versionCreated` branch.
- Out of scope, deliberately deferred: ext-based fallback in `shouldCreateVersion` and/or repairing the missing ContentType metadata. Get diagnostic data to confirm root cause before changing the gate.

## Test plan

- [x] `npm run lint` clean on touched files
- [x] `npm test` -- 392 passing including the new regression; 100% line coverage on `src/storage/version/put.js`
- [ ] Post-deploy: re-run the diagnostic log query 24h later -- the new `Failed to version (no version created)` row should appear with the dominant URL set, confirming the contentType-missing theory.

## Refs

- Prior fix on the same endpoint: #271 (412 race)
- Original surfacing: #250

Replaces #283 (which referenced an internal tracker id in its branch name; closed without merge).