### PR TITLE
fix(version): heal ContentType for legacy octet-stream files on labelled version

### DIFF
--- a/src/storage/version/put.js
+++ b/src/storage/version/put.js
@@ -78,6 +78,16 @@ function shouldCreateVersion(contentType) {
   return type.startsWith('text/html') || type.startsWith('application/json');
 }
 
+// Infer a versionable contentType from the file extension when the stored
+// ContentType is missing or octet-stream (legacy imports). Returns the original
+// contentType when it is already versionable, or when we cannot map the extension.
+function inferVersionableType(contentType, ext) {
+  if (shouldCreateVersion(contentType)) return contentType;
+  if (ext === 'html') return 'text/html';
+  if (ext === 'json') return 'application/json';
+  return contentType;
+}
+
 function buildInput({
   bucket, org, key, body, type, contentLength,
 }) {
@@ -112,10 +122,9 @@ export async function putObjectWithVersion(
     return { status: 409, metadata: { id: ID } };
   }
 
+  // Only create versions for HTML and JSON files
   const contentType = update.type || current.contentType;
-  // For named versions (POST /versionsource) we always create, even when the source
-  // object lacks a versionable contentType (legacy imports stored as octet-stream).
-  const createVersion = shouldCreateVersion(contentType) || update.label != null;
+  const createVersion = shouldCreateVersion(contentType);
 
   const Version = current.metadata?.version || crypto.randomUUID();
   const Users = JSON.stringify(getUsersForMetadata(daCtx.users));
@@ -226,7 +235,7 @@ export async function putObjectWithVersion(
       Repo: daCtx.site || undefined,
       Body: (body || storeBody ? current.body : ''),
       ContentLength: (body || storeBody ? current.contentLength : undefined),
-      ContentType: current.contentType,
+      ContentType: contentType,
       ID,
       Version,
       Ext: daCtx.ext,
@@ -323,8 +332,13 @@ export async function postObjectVersionWithLabel(label, env, daCtx) {
   const bodyBuffer = body instanceof ReadableStream ? await new Response(body).arrayBuffer() : body;
   const { bucket, org, key } = daCtx;
 
+  // Legacy imports may have lost their ContentType metadata (stored as
+  // application/octet-stream). Recover the correct mime from the file
+  // extension so the version write + main-object PUT both heal.
+  const inferredType = inferVersionableType(contentType, daCtx.ext);
+
   const resp = await putObjectWithVersion(env, daCtx, {
-    bucket, org, key, body: bodyBuffer, contentLength, type: contentType, label,
+    bucket, org, key, body: bodyBuffer, contentLength, type: inferredType, label,
   }, true);
 
   if (resp.status !== 200) return { status: resp.status };
@@ -335,6 +349,8 @@ export async function postObjectVersionWithLabel(label, env, daCtx) {
     // eslint-disable-next-line no-console
     console.error('Failed to version (no version created)', {
       contentType,
+      inferredType,
+      ext: daCtx.ext,
       hadLabel: label != null,
       currentStatus,
     });

--- a/src/storage/version/put.js
+++ b/src/storage/version/put.js
@@ -112,9 +112,10 @@ export async function putObjectWithVersion(
     return { status: 409, metadata: { id: ID } };
   }
 
-  // Only create versions for HTML and JSON files
   const contentType = update.type || current.contentType;
-  const createVersion = shouldCreateVersion(contentType);
+  // For named versions (POST /versionsource) we always create, even when the source
+  // object lacks a versionable contentType (legacy imports stored as octet-stream).
+  const createVersion = shouldCreateVersion(contentType) || update.label != null;
 
   const Version = current.metadata?.version || crypto.randomUUID();
   const Users = JSON.stringify(getUsersForMetadata(daCtx.users));

--- a/test/storage/version/put.test.js
+++ b/test/storage/version/put.test.js
@@ -3162,8 +3162,8 @@ describe('Version Put', () => {
       assert.strictEqual(resp.status, 201, 'must return 201 when version already exists (concurrent 412)');
     });
 
-    it('returns 201 when source contentType is application/octet-stream and a label is provided (COR-55)', async () => {
-      // Regression for COR-55: legacy imports with missing/octet-stream ContentType metadata
+    it('returns 201 when source contentType is application/octet-stream and a label is provided', async () => {
+      // Regression: legacy imports with missing/octet-stream ContentType metadata
       // returned a silent 500 because shouldCreateVersion gated out non-html/json. When the
       // caller passes an explicit label (POST /versionsource), the version MUST be created
       // regardless of contentType, and the audit entry MUST be written.
@@ -3221,7 +3221,7 @@ describe('Version Put', () => {
     });
 
     it('plain PUT (no label) still skips auto-version for non-html/json contentType', async () => {
-      // Companion regression to confirm the COR-55 fix only widens the LABELED path.
+      // Companion regression to confirm the fix only widens the LABELED path.
       // Auto-versioning on plain PUT must still gate to html/json (no extra storage cost).
       const versionWrites = [];
       const mainWrites = [];

--- a/test/storage/version/put.test.js
+++ b/test/storage/version/put.test.js
@@ -3162,21 +3162,22 @@ describe('Version Put', () => {
       assert.strictEqual(resp.status, 201, 'must return 201 when version already exists (concurrent 412)');
     });
 
-    it('returns 201 when source contentType is application/octet-stream and a label is provided', async () => {
-      // Regression: legacy imports with missing/octet-stream ContentType metadata
-      // returned a silent 500 because shouldCreateVersion gated out non-html/json. When the
-      // caller passes an explicit label (POST /versionsource), the version MUST be created
-      // regardless of contentType, and the audit entry MUST be written.
+    it('heals legacy octet-stream HTML on labelled version: snapshot + main object both repaired', async () => {
+      // Regression: legacy imports with missing or octet-stream ContentType could not be
+      // labelled-versioned because shouldCreateVersion gated out non-html/json. Recover the
+      // correct mime from the file extension so the version snapshot AND the main-object PUT
+      // both heal to text/html.
       const versionWrites = [];
+      const mainWrites = [];
       const auditCalls = [];
 
       const mockGetObject = async () => ({
-        body: 'binary content',
+        body: '<html>legacy</html>',
         contentType: 'application/octet-stream',
-        contentLength: 14,
+        contentLength: 18,
         status: 200,
         metadata: {
-          id: 'octet-id', version: 'v1', timestamp: '123', users: '[]', path: '/legacy/file',
+          id: 'legacy-id', version: 'v1', timestamp: '123', users: '[]', path: '/mysite/legacy.html',
         },
         etag: '"etag1"',
       });
@@ -3188,7 +3189,8 @@ describe('Version Put', () => {
         },
       };
       const mainClient = {
-        async send() {
+        async send(cmd) {
+          mainWrites.push(cmd.input);
           return { $metadata: { httpStatusCode: 200 } };
         },
       };
@@ -3208,21 +3210,79 @@ describe('Version Put', () => {
       });
 
       const daCtx = {
-        bucket: 'b', org: 'o', site: 'mysite', key: 'mysite/legacy/file', ext: 'dat', users: [],
+        bucket: 'b', org: 'o', site: 'mysite', key: 'mysite/legacy.html', ext: 'html', users: [],
       };
       const resp = await postObjectVersionWithLabel('Pre-import snapshot', {}, daCtx);
 
-      assert.strictEqual(resp.status, 201, 'labelled version must succeed for octet-stream content');
-      assert.strictEqual(versionWrites.length, 1, 'version snapshot must be written even for octet-stream');
+      assert.strictEqual(resp.status, 201);
+      assert.strictEqual(versionWrites.length, 1, 'version snapshot must be written');
+      assert.strictEqual(versionWrites[0].ContentType, 'text/html', 'snapshot ContentType must heal to text/html');
       assert.strictEqual(versionWrites[0].Metadata.Label, 'Pre-import snapshot');
-      assert.strictEqual(auditCalls.length, 1, 'audit entry must be written for labelled non-html/json version');
+      assert.strictEqual(mainWrites.length, 1, 'main object PUT must run');
+      assert.strictEqual(mainWrites[0].ContentType, 'text/html', 'main object ContentType must heal in storage');
+      assert.strictEqual(auditCalls.length, 1, 'audit entry must be written');
       assert.strictEqual(auditCalls[0].entry.versionLabel, 'Pre-import snapshot');
-      assert.ok(auditCalls[0].entry.versionId, 'audit entry must include versionId for labelled version');
+      assert.ok(auditCalls[0].entry.versionId);
     });
 
+    it('logs diagnostics and returns 500 when labelled version requested on non-versionable ext', async () => {
+      // Preserves the binary-never-version semantics: when the file extension does not map
+      // to a versionable mime (and the stored contentType is also not versionable), the
+      // labelled-version request still 500s and the diagnostic log fires with inferredType + ext
+      // captured so we can spot future legacy patterns in Cloudflare Logs.
+      const mockGetObject = async () => ({
+        body: 'binary content',
+        contentType: 'application/octet-stream',
+        contentLength: 14,
+        status: 200,
+        metadata: { id: 'bin-id', version: 'v1' },
+        etag: '"etag1"',
+      });
+
+      const s3Client = {
+        async send() { return { $metadata: { httpStatusCode: 200 } }; },
+      };
+
+      const { postObjectVersionWithLabel } = await esmock('../../../src/storage/version/put.js', {
+        '../../../src/storage/object/get.js': { default: mockGetObject },
+        '../../../src/storage/utils/version.js': {
+          ifNoneMatch: () => s3Client,
+          ifMatch: () => s3Client,
+        },
+        '../../../src/storage/version/audit.js': { writeAuditEntry: async () => ({ status: 200 }) },
+        '../../../src/storage/utils/config.js': { default: () => ({}) },
+      });
+
+      const daCtx = {
+        bucket: 'b', org: 'o', site: 'mysite', key: 'mysite/data.bin', ext: 'bin', users: [],
+      };
+
+      const errors = [];
+      const origError = console.error;
+      console.error = (...args) => {
+        errors.push(args);
+      };
+      let resp;
+      try {
+        resp = await postObjectVersionWithLabel('My Label', {}, daCtx);
+      } finally {
+        console.error = origError;
+      }
+
+      assert.strictEqual(resp.status, 500);
+      assert.strictEqual(resp.error, 'Version was not created');
+      assert(errors.length > 0, 'diagnostic log must fire for the unhealed octet-stream path');
+      const payload = errors[0].find((a) => a && typeof a === 'object');
+      assert(payload, 'log must include a structured diagnostic payload');
+      assert.strictEqual(payload.contentType, 'application/octet-stream');
+      assert.strictEqual(payload.inferredType, 'application/octet-stream', 'inference must fall through for unknown ext');
+      assert.strictEqual(payload.ext, 'bin');
+      assert.strictEqual(payload.hadLabel, true);
+      assert.strictEqual(payload.currentStatus, 200);
+    });
     it('plain PUT (no label) still skips auto-version for non-html/json contentType', async () => {
-      // Companion regression to confirm the fix only widens the LABELED path.
-      // Auto-versioning on plain PUT must still gate to html/json (no extra storage cost).
+      // Companion regression: the labelled-path mime inference must NOT bleed into plain
+      // PUTs. Auto-versioning on plain PUT must still gate to html/json (no extra storage cost).
       const versionWrites = [];
       const mainWrites = [];
 

--- a/test/storage/version/put.test.js
+++ b/test/storage/version/put.test.js
@@ -3162,28 +3162,35 @@ describe('Version Put', () => {
       assert.strictEqual(resp.status, 201, 'must return 201 when version already exists (concurrent 412)');
     });
 
-    it('logs diagnostics when versionCreated is false (silent 500 path)', async () => {
-      // Regression: legacy HTML imports can land in storage with no S3
-      // ContentType metadata. shouldCreateVersion(undefined) returns false ->
-      // shouldCreateVersionObject is false -> putObjectWithVersion returns
-      // { status: 200, versionCreated: false } -> postObjectVersionWithLabel
-      // returns a silent 500 with empty Cloudflare Logs (no console.error).
-      // The fix adds a single diagnostic log capturing contentType / hadLabel /
-      // currentStatus so the next daily review can confirm root cause.
+    it('returns 201 when source contentType is application/octet-stream and a label is provided (COR-55)', async () => {
+      // Regression for COR-55: legacy imports with missing/octet-stream ContentType metadata
+      // returned a silent 500 because shouldCreateVersion gated out non-html/json. When the
+      // caller passes an explicit label (POST /versionsource), the version MUST be created
+      // regardless of contentType, and the audit entry MUST be written.
+      const versionWrites = [];
+      const auditCalls = [];
+
       const mockGetObject = async () => ({
-        body: 'doc content',
-        contentType: undefined,
-        contentLength: 200,
+        body: 'binary content',
+        contentType: 'application/octet-stream',
+        contentLength: 14,
         status: 200,
-        metadata: { id: 'doc-id', version: 'v1' },
+        metadata: {
+          id: 'octet-id', version: 'v1', timestamp: '123', users: '[]', path: '/legacy/file',
+        },
         etag: '"etag1"',
       });
 
-      const mainClient = {
-        async send() { return { $metadata: { httpStatusCode: 200 } }; },
-      };
       const versionClient = {
-        async send() { return { $metadata: { httpStatusCode: 200 } }; },
+        async send(cmd) {
+          versionWrites.push(cmd.input);
+          return { $metadata: { httpStatusCode: 200 } };
+        },
+      };
+      const mainClient = {
+        async send() {
+          return { $metadata: { httpStatusCode: 200 } };
+        },
       };
 
       const { postObjectVersionWithLabel } = await esmock('../../../src/storage/version/put.js', {
@@ -3193,35 +3200,75 @@ describe('Version Put', () => {
           ifMatch: () => mainClient,
         },
         '../../../src/storage/version/audit.js': {
-          writeAuditEntry: async () => ({ status: 200 }),
+          writeAuditEntry: async (env, ctx, repo, fileId, entry) => {
+            auditCalls.push({ repo, fileId, entry });
+          },
         },
         '../../../src/storage/utils/config.js': { default: () => ({}) },
       });
 
       const daCtx = {
-        bucket: 'b', org: 'o', key: 'doc.html', ext: 'html', users: [],
+        bucket: 'b', org: 'o', site: 'mysite', key: 'mysite/legacy/file', ext: 'dat', users: [],
+      };
+      const resp = await postObjectVersionWithLabel('Pre-import snapshot', {}, daCtx);
+
+      assert.strictEqual(resp.status, 201, 'labelled version must succeed for octet-stream content');
+      assert.strictEqual(versionWrites.length, 1, 'version snapshot must be written even for octet-stream');
+      assert.strictEqual(versionWrites[0].Metadata.Label, 'Pre-import snapshot');
+      assert.strictEqual(auditCalls.length, 1, 'audit entry must be written for labelled non-html/json version');
+      assert.strictEqual(auditCalls[0].entry.versionLabel, 'Pre-import snapshot');
+      assert.ok(auditCalls[0].entry.versionId, 'audit entry must include versionId for labelled version');
+    });
+
+    it('plain PUT (no label) still skips auto-version for non-html/json contentType', async () => {
+      // Companion regression to confirm the COR-55 fix only widens the LABELED path.
+      // Auto-versioning on plain PUT must still gate to html/json (no extra storage cost).
+      const versionWrites = [];
+      const mainWrites = [];
+
+      const mockGetObject = async () => ({
+        body: 'binary content',
+        contentType: 'application/octet-stream',
+        contentLength: 14,
+        status: 200,
+        metadata: {
+          id: 'octet-id', version: 'v1', timestamp: '123', users: '[]', path: '/legacy/file',
+        },
+        etag: '"etag1"',
+      });
+
+      const versionClient = {
+        async send(cmd) {
+          versionWrites.push(cmd.input);
+          return { $metadata: { httpStatusCode: 200 } };
+        },
+      };
+      const mainClient = {
+        async send(cmd) {
+          mainWrites.push(cmd.input);
+          return { $metadata: { httpStatusCode: 200 } };
+        },
       };
 
-      const errors = [];
-      const origError = console.error;
-      console.error = (...args) => {
-        errors.push(args);
-      };
-      let resp;
-      try {
-        resp = await postObjectVersionWithLabel('My Label', {}, daCtx);
-      } finally {
-        console.error = origError;
-      }
+      const { putObjectWithVersion } = await esmock('../../../src/storage/version/put.js', {
+        '../../../src/storage/object/get.js': { default: mockGetObject },
+        '../../../src/storage/utils/version.js': {
+          ifNoneMatch: () => versionClient,
+          ifMatch: () => mainClient,
+        },
+      });
 
-      assert.strictEqual(resp.status, 500);
-      assert.strictEqual(resp.error, 'Version was not created');
-      assert(errors.length > 0, 'silent-500 path must emit a console.error so Cloudflare Logs is non-empty');
-      const payload = errors[0].find((a) => a && typeof a === 'object');
-      assert(payload, 'log must include a structured diagnostic payload');
-      assert.strictEqual(payload.contentType, undefined, 'payload must record contentType (undefined when source metadata is missing)');
-      assert.strictEqual(payload.hadLabel, true, 'payload must record whether a label was supplied');
-      assert.strictEqual(payload.currentStatus, 200, 'payload must record the source-object status');
+      const daCtx = {
+        org: 'o', ext: 'bin', site: 'mysite', users: [{ email: 'u@x.com' }],
+      };
+      const update = {
+        org: 'o', key: 'mysite/legacy/file', body: 'new', type: 'application/octet-stream',
+      };
+      const resp = await putObjectWithVersion({}, daCtx, update, true);
+
+      assert.strictEqual(resp.status, 200);
+      assert.strictEqual(versionWrites.length, 0, 'no version snapshot for plain octet-stream PUT without label');
+      assert.strictEqual(mainWrites.length, 1, 'main object updated once');
     });
 
     it('returns 201 when version client body is a ReadableStream that would be disturbed by SDK retry', async () => {


### PR DESCRIPTION
## Summary (revised after board pushback)

`POST /versionsource` returned a **silent 500** for legacy imports whose source object was stored with `ContentType: application/octet-stream` (or no ContentType). The diagnostic from #284 confirmed 9/24h occurrences with that identical fingerprint.

## Fix (was A, now B)

Original proposal (A) was to widen the gate: `createVersion = shouldCreateVersion(contentType) || update.label != null`. Board flagged that we should fix the underlying ContentType rather than let bad metadata through.

This PR ships **fix B**: in `postObjectVersionWithLabel`, infer the correct mime from `daCtx.ext` when the stored ContentType is missing or octet-stream, then pass that inferred type through `update.type`.

```js
// src/storage/version/put.js
function inferVersionableType(contentType, ext) {
  if (shouldCreateVersion(contentType)) return contentType;
  if (ext === 'html') return 'text/html';
  if (ext === 'json') return 'application/json';
  return contentType;
}
```

Effects:

- Legacy .html files stored as octet-stream now get a labelled version. The version snapshot is correctly tagged `text/html`.
- The main object's PUT (the one that always runs in this code path) writes the inferred ContentType into S3 metadata, so the file is **self-healed** for all future requests. Auto-versioning on the next plain PUT now works because shouldCreateVersion(text/html) returns true.
- The shouldCreateVersion gate is unchanged. Binary files (jpg/pdf/mp4/etc.) still cannot be labelled-versioned, matching the project's existing "binaries do not version" semantics that JPEG/PNG/PDF/MP4/SVG/ZIP tests already assert.
- The diagnostic log from #284 stays in place and is extended with `inferredType` + `ext`, so any future unhealed pattern is still observable in Cloudflare Logs.

## Tests

- `heals legacy octet-stream HTML on labelled version: snapshot + main object both repaired` - asserts the version snapshot has `ContentType: text/html`, the main object PUT writes `ContentType: text/html`, the audit entry is emitted with versionLabel + versionId.
- `logs diagnostics and returns 500 when labelled version requested on non-versionable ext` - asserts the silent-500 path still 500s for unknown extensions, and the diagnostic log captures contentType / inferredType / ext / hadLabel / currentStatus.
- `plain PUT (no label) still skips auto-version for non-html/json contentType` - companion to confirm the labelled-path mime inference does not bleed into auto-versioning.
- All existing tests pass; binary-never-version tests untouched.

```
npx eslint src test  ->  clean
npm test             ->  393 passing (audit timeout flake unrelated)
```

## Risk

- Mime inference is narrow (only html/json). Files with truly unknown extensions still 500, which is consistent with current behavior.
- Storage cost increases for the labelled-version writes that previously failed (bounded by the actual call rate, <=9/24h).
- The S3 ContentType is now mutated when we heal a legacy object. Mutation only happens on the labelled-version code path, which already PUTs the main object as part of its normal flow. No new write.

## Refs

- COR-55 (this fix), COR-46 (diagnostic ship), #284 (diagnostic PR)