### PR TITLE
log(audit): add repo + fileId to writeAuditEntry failure log

### DIFF
--- a/src/storage/version/audit.js
+++ b/src/storage/version/audit.js
@@ -287,7 +287,7 @@ export async function writeAuditEntry(env, ctx, repo, fileId, entry, attempt = 0
     }
   } catch (e) {
     // eslint-disable-next-line no-console
-    console.error('writeAuditEntry failed', e);
+    console.error('writeAuditEntry failed', { repo, fileId }, e);
     return { status: 500, error: e.message };
   }
 }


### PR DESCRIPTION
## Summary

- `writeAuditEntry` currently logs only the raw SDK error on failure — no way to pivot by file in Coralogix
- Adds `repo` and `fileId` to the error payload so failures can be correlated to specific files
- No functional change — log shape only

## Motivation (COR-61)

We have 10,055 `writeAuditEntry` failures per day but can't tell whether they cluster on a handful of hot files or spread uniformly. The file identity is the missing pivot:
- If concentrated → specific documents are getting concurrent writes (da-collab + direct browser/API writes racing on the same `audit.txt`)
- If spread → something systemic (e.g. R2 throttling, transient network errors)

This diagnostic log is the prerequisite before we can pick the right fix (COR-61).

## Test plan

- [ ] Deploy to stage, trigger a PUT on an HTML file, verify Coralogix shows `{ repo, fileId }` next to any `writeAuditEntry failed` entries
- [ ] Confirm no `writeAuditEntry failed` entries appear for normal single-writer saves

🤖 Generated with [Claude Code](https://claude.com/claude-code)