### PR TITLE
test(audit): fix flaky 412-retry backoff tests with `setTimeout` stub

### DIFF
--- a/test/storage/version/audit.test.js
+++ b/test/storage/version/audit.test.js
@@ -814,27 +814,40 @@ describe('Version Audit', () => {
       assert.strictEqual(lines.length, 2, 'both entries must be present (no collapse across mismatched users)');
     });
 
-    it('returns status 500 when PUT 412 persists across all 7 attempts', async () => {
-      // Stubs setTimeout so the ~3050ms worst-case retry backoff (see
-      // audit.js) doesn't race mocha's 2000ms default test timeout.
-      const originalSetTimeout = globalThis.setTimeout;
-      globalThis.setTimeout = (fn) => {
-        fn();
-        return 0;
-      };
+    describe('412 retry backoff', () => {
+      // These tests exercise the real retry loop in writeAuditEntry, which
+      // sleeps between attempts with real exponential-jitter setTimeout
+      // delays (worst case ~3050ms across 6 retries, see audit.js). Real
+      // delays here would race mocha's 2000ms default test timeout, so every
+      // test in this block stubs setTimeout to fire immediately. The hook
+      // only owns save/restore of the reference — each test installs
+      // whatever replacement behavior it needs (some also capture delays).
+      let originalSetTimeout;
 
-      let getCallCount = 0;
-      let putCallCount = 0;
-
-      const makeBody = () => new ReadableStream({
-        start(controller) {
-          controller.enqueue(new TextEncoder().encode(''));
-          controller.close();
-        },
+      beforeEach(() => {
+        originalSetTimeout = globalThis.setTimeout;
       });
 
-      let result;
-      try {
+      afterEach(() => {
+        globalThis.setTimeout = originalSetTimeout;
+      });
+
+      it('returns status 500 when PUT 412 persists across all 7 attempts', async () => {
+        globalThis.setTimeout = (fn) => {
+          fn();
+          return 0;
+        };
+
+        let getCallCount = 0;
+        let putCallCount = 0;
+
+        const makeBody = () => new ReadableStream({
+          start(controller) {
+            controller.enqueue(new TextEncoder().encode(''));
+            controller.close();
+          },
+        });
+
         const { writeAuditEntry } = await esmock(
           '../../../src/storage/version/audit.js',
           {
@@ -861,36 +874,112 @@ describe('Version Audit', () => {
           },
         );
 
-        result = await writeAuditEntry({}, { bucket: 'b', org: 'o' }, 'repo', 'fid', {
+        const result = await writeAuditEntry({}, { bucket: 'b', org: 'o' }, 'repo', 'fid', {
           timestamp: '5000',
           users: '[{"email":"u@x.com"}]',
           path: 'repo/doc.html',
         });
-      } finally {
-        globalThis.setTimeout = originalSetTimeout;
-      }
 
-      assert.strictEqual(result.status, 500, 'persistent 412 must surface as 500 after 7 total attempts');
-      assert.strictEqual(result.error, 'precondition failed');
-      assert.strictEqual(putCallCount, 7, 'must attempt PUT 7 times total (1 initial + 6 retries)');
-      assert.strictEqual(getCallCount, 7, 'must re-read on each attempt');
-    });
+        assert.strictEqual(result.status, 500, 'persistent 412 must surface as 500 after 7 total attempts');
+        assert.strictEqual(result.error, 'precondition failed');
+        assert.strictEqual(putCallCount, 7, 'must attempt PUT 7 times total (1 initial + 6 retries)');
+        assert.strictEqual(getCallCount, 7, 'must re-read on each attempt');
+      });
 
-    it('uses exponential jitter backoff (0-50, 0-100, 0-200, 0-400, 0-800, 0-1600 ms) across six 412 retries', async () => {
-      // Stubs setTimeout and Math.random to capture per-retry delays.
-      // Asserts per-attempt exponential upper bounds for the 6-retry ladder
-      // (50, 100, 200, 400, 800, 1600 ms) and total elapsed sleep ~3050 ms.
-      const originalSetTimeout = globalThis.setTimeout;
-      const originalRandom = Math.random;
-      const delays = [];
-      Math.random = () => 0.999999;
-      globalThis.setTimeout = (fn, ms) => {
-        delays.push(ms);
-        fn();
-        return 0;
-      };
+      it('uses exponential jitter backoff (0-50, 0-100, 0-200, 0-400, 0-800, 0-1600 ms) across six 412 retries', async () => {
+        // Also stubs Math.random to capture per-retry delays. Asserts
+        // per-attempt exponential upper bounds for the 6-retry ladder
+        // (50, 100, 200, 400, 800, 1600 ms) and total elapsed sleep ~3050 ms.
+        const originalRandom = Math.random;
+        const delays = [];
+        Math.random = () => 0.999999;
+        globalThis.setTimeout = (fn, ms) => {
+          delays.push(ms);
+          fn();
+          return 0;
+        };
 
-      try {
+        try {
+          const makeBody = () => new ReadableStream({
+            start(controller) {
+              controller.enqueue(new TextEncoder().encode(''));
+              controller.close();
+            },
+          });
+
+          const { writeAuditEntry } = await esmock(
+            '../../../src/storage/version/audit.js',
+            {
+              '@aws-sdk/client-s3': {
+                S3Client: function S3Client() {
+                  this.send = async (cmd) => {
+                    if (cmd instanceof GetObjectCommand) {
+                      return { Body: makeBody(), ETag: '"etag-x"' };
+                    }
+                    if (cmd instanceof PutObjectCommand) {
+                      const err = new Error('precondition failed');
+                      err.$metadata = { httpStatusCode: 412 };
+                      throw err;
+                    }
+                    return { $metadata: { httpStatusCode: 200 } };
+                  };
+                },
+                GetObjectCommand,
+                PutObjectCommand,
+              },
+              '../../../src/storage/utils/config.js': { default: () => ({}) },
+            },
+          );
+
+          await writeAuditEntry({}, { bucket: 'b', org: 'o' }, 'repo', 'fid', {
+            timestamp: '5000',
+            users: '[{"email":"u@x.com"}]',
+            path: 'repo/doc.html',
+          });
+        } finally {
+          Math.random = originalRandom;
+        }
+
+        assert.strictEqual(delays.length, 6, 'must sleep between each of the 6 retries');
+        const upperBounds = [50, 100, 200, 400, 800, 1600];
+        delays.forEach((ms, i) => {
+          assert.ok(
+            ms >= 0 && ms < upperBounds[i],
+            `delay[${i}]=${ms} must be within [0, ${upperBounds[i]})`,
+          );
+        });
+        assert.ok(
+          delays[2] >= 150,
+          `delay[2]=${delays[2]} must exceed the prior linear cap of 150 ms`,
+        );
+        assert.ok(
+          delays[3] >= 200,
+          `delay[3]=${delays[3]} must exceed the prior linear cap of 200 ms`,
+        );
+        assert.ok(
+          delays[5] >= 800,
+          `delay[5]=${delays[5]} must reach the new 6-retry exponential ceiling (>=800 ms)`,
+        );
+        const total = delays.reduce((a, b) => a + b, 0);
+        assert.ok(
+          total > 1500,
+          `total elapsed sleep ${total} must exceed prior 4-retry worst-case (~750 ms)`,
+        );
+        assert.ok(
+          total < 3200,
+          `total elapsed sleep ${total} must stay within the new 6-retry worst-case (~3050 ms)`,
+        );
+      });
+
+      it('succeeds on the 5th attempt after four 412s', async () => {
+        globalThis.setTimeout = (fn) => {
+          fn();
+          return 0;
+        };
+
+        let getCallCount = 0;
+        let putCallCount = 0;
+
         const makeBody = () => new ReadableStream({
           start(controller) {
             controller.enqueue(new TextEncoder().encode(''));
@@ -905,12 +994,17 @@ describe('Version Audit', () => {
               S3Client: function S3Client() {
                 this.send = async (cmd) => {
                   if (cmd instanceof GetObjectCommand) {
-                    return { Body: makeBody(), ETag: '"etag-x"' };
+                    getCallCount += 1;
+                    return { Body: makeBody(), ETag: `"etag-${getCallCount}"` };
                   }
                   if (cmd instanceof PutObjectCommand) {
-                    const err = new Error('precondition failed');
-                    err.$metadata = { httpStatusCode: 412 };
-                    throw err;
+                    putCallCount += 1;
+                    if (putCallCount < 5) {
+                      const err = new Error('precondition failed');
+                      err.$metadata = { httpStatusCode: 412 };
+                      throw err;
+                    }
+                    return { $metadata: { httpStatusCode: 200 } };
                   }
                   return { $metadata: { httpStatusCode: 200 } };
                 };
@@ -922,96 +1016,16 @@ describe('Version Audit', () => {
           },
         );
 
-        await writeAuditEntry({}, { bucket: 'b', org: 'o' }, 'repo', 'fid', {
+        const result = await writeAuditEntry({}, { bucket: 'b', org: 'o' }, 'repo', 'fid', {
           timestamp: '5000',
           users: '[{"email":"u@x.com"}]',
           path: 'repo/doc.html',
         });
-      } finally {
-        globalThis.setTimeout = originalSetTimeout;
-        Math.random = originalRandom;
-      }
 
-      assert.strictEqual(delays.length, 6, 'must sleep between each of the 6 retries');
-      const upperBounds = [50, 100, 200, 400, 800, 1600];
-      delays.forEach((ms, i) => {
-        assert.ok(
-          ms >= 0 && ms < upperBounds[i],
-          `delay[${i}]=${ms} must be within [0, ${upperBounds[i]})`,
-        );
+        assert.strictEqual(result.status, 200, 'must succeed on the 5th attempt');
+        assert.strictEqual(putCallCount, 5, 'must have attempted PUT 5 times');
+        assert.strictEqual(getCallCount, 5, 'must re-read on each attempt');
       });
-      assert.ok(
-        delays[2] >= 150,
-        `delay[2]=${delays[2]} must exceed the prior linear cap of 150 ms`,
-      );
-      assert.ok(
-        delays[3] >= 200,
-        `delay[3]=${delays[3]} must exceed the prior linear cap of 200 ms`,
-      );
-      assert.ok(
-        delays[5] >= 800,
-        `delay[5]=${delays[5]} must reach the new 6-retry exponential ceiling (>=800 ms)`,
-      );
-      const total = delays.reduce((a, b) => a + b, 0);
-      assert.ok(
-        total > 1500,
-        `total elapsed sleep ${total} must exceed prior 4-retry worst-case (~750 ms)`,
-      );
-      assert.ok(
-        total < 3200,
-        `total elapsed sleep ${total} must stay within the new 6-retry worst-case (~3050 ms)`,
-      );
-    });
-
-    it('succeeds on the 5th attempt after four 412s', async () => {
-      let getCallCount = 0;
-      let putCallCount = 0;
-
-      const makeBody = () => new ReadableStream({
-        start(controller) {
-          controller.enqueue(new TextEncoder().encode(''));
-          controller.close();
-        },
-      });
-
-      const { writeAuditEntry } = await esmock(
-        '../../../src/storage/version/audit.js',
-        {
-          '@aws-sdk/client-s3': {
-            S3Client: function S3Client() {
-              this.send = async (cmd) => {
-                if (cmd instanceof GetObjectCommand) {
-                  getCallCount += 1;
-                  return { Body: makeBody(), ETag: `"etag-${getCallCount}"` };
-                }
-                if (cmd instanceof PutObjectCommand) {
-                  putCallCount += 1;
-                  if (putCallCount < 5) {
-                    const err = new Error('precondition failed');
-                    err.$metadata = { httpStatusCode: 412 };
-                    throw err;
-                  }
-                  return { $metadata: { httpStatusCode: 200 } };
-                }
-                return { $metadata: { httpStatusCode: 200 } };
-              };
-            },
-            GetObjectCommand,
-            PutObjectCommand,
-          },
-          '../../../src/storage/utils/config.js': { default: () => ({}) },
-        },
-      );
-
-      const result = await writeAuditEntry({}, { bucket: 'b', org: 'o' }, 'repo', 'fid', {
-        timestamp: '5000',
-        users: '[{"email":"u@x.com"}]',
-        path: 'repo/doc.html',
-      });
-
-      assert.strictEqual(result.status, 200, 'must succeed on the 5th attempt');
-      assert.strictEqual(putCallCount, 5, 'must have attempted PUT 5 times');
-      assert.strictEqual(getCallCount, 5, 'must re-read on each attempt');
     });
   });
 });

--- a/test/storage/version/audit.test.js
+++ b/test/storage/version/audit.test.js
@@ -815,13 +815,8 @@ describe('Version Audit', () => {
     });
 
     describe('412 retry backoff', () => {
-      // These tests exercise the real retry loop in writeAuditEntry, which
-      // sleeps between attempts with real exponential-jitter setTimeout
-      // delays (worst case ~3050ms across 6 retries, see audit.js). Real
-      // delays here would race mocha's 2000ms default test timeout, so every
-      // test in this block stubs setTimeout to fire immediately. The hook
-      // only owns save/restore of the reference — each test installs
-      // whatever replacement behavior it needs (some also capture delays).
+      // Real retry delays (~3050ms worst case) would exceed mocha's 2000ms
+      // timeout, so each test stubs setTimeout; the hook just restores it.
       let originalSetTimeout;
 
       beforeEach(() => {
@@ -887,9 +882,7 @@ describe('Version Audit', () => {
       });
 
       it('uses exponential jitter backoff (0-50, 0-100, 0-200, 0-400, 0-800, 0-1600 ms) across six 412 retries', async () => {
-        // Also stubs Math.random to capture per-retry delays. Asserts
-        // per-attempt exponential upper bounds for the 6-retry ladder
-        // (50, 100, 200, 400, 800, 1600 ms) and total elapsed sleep ~3050 ms.
+        // Also stubs Math.random to capture per-retry delays.
         const originalRandom = Math.random;
         const delays = [];
         Math.random = () => 0.999999;

--- a/test/storage/version/audit.test.js
+++ b/test/storage/version/audit.test.js
@@ -815,8 +815,7 @@ describe('Version Audit', () => {
     });
 
     describe('412 retry backoff', () => {
-      // Real retry delays (~3050ms worst case) would exceed mocha's 2000ms
-      // timeout, so each test stubs setTimeout; the hook just restores it.
+      // stub/restore setTimeout to avoid exceeding mocha 2000ms timeout
       let originalSetTimeout;
 
       beforeEach(() => {

--- a/test/storage/version/audit.test.js
+++ b/test/storage/version/audit.test.js
@@ -881,7 +881,7 @@ describe('Version Audit', () => {
       });
 
       it('uses exponential jitter backoff (0-50, 0-100, 0-200, 0-400, 0-800, 0-1600 ms) across six 412 retries', async () => {
-        // Also stubs Math.random to capture per-retry delays.
+        // stub Math.random so we can capture per-retry delays
         const originalRandom = Math.random;
         const delays = [];
         Math.random = () => 0.999999;

--- a/test/storage/version/audit.test.js
+++ b/test/storage/version/audit.test.js
@@ -815,6 +815,14 @@ describe('Version Audit', () => {
     });
 
     it('returns status 500 when PUT 412 persists across all 7 attempts', async () => {
+      // Stubs setTimeout so the ~3050ms worst-case retry backoff (see
+      // audit.js) doesn't race mocha's 2000ms default test timeout.
+      const originalSetTimeout = globalThis.setTimeout;
+      globalThis.setTimeout = (fn) => {
+        fn();
+        return 0;
+      };
+
       let getCallCount = 0;
       let putCallCount = 0;
 
@@ -825,37 +833,42 @@ describe('Version Audit', () => {
         },
       });
 
-      const { writeAuditEntry } = await esmock(
-        '../../../src/storage/version/audit.js',
-        {
-          '@aws-sdk/client-s3': {
-            S3Client: function S3Client() {
-              this.send = async (cmd) => {
-                if (cmd instanceof GetObjectCommand) {
-                  getCallCount += 1;
-                  return { Body: makeBody(), ETag: '"etag-x"' };
-                }
-                if (cmd instanceof PutObjectCommand) {
-                  putCallCount += 1;
-                  const err = new Error('precondition failed');
-                  err.$metadata = { httpStatusCode: 412 };
-                  throw err;
-                }
-                return { $metadata: { httpStatusCode: 200 } };
-              };
+      let result;
+      try {
+        const { writeAuditEntry } = await esmock(
+          '../../../src/storage/version/audit.js',
+          {
+            '@aws-sdk/client-s3': {
+              S3Client: function S3Client() {
+                this.send = async (cmd) => {
+                  if (cmd instanceof GetObjectCommand) {
+                    getCallCount += 1;
+                    return { Body: makeBody(), ETag: '"etag-x"' };
+                  }
+                  if (cmd instanceof PutObjectCommand) {
+                    putCallCount += 1;
+                    const err = new Error('precondition failed');
+                    err.$metadata = { httpStatusCode: 412 };
+                    throw err;
+                  }
+                  return { $metadata: { httpStatusCode: 200 } };
+                };
+              },
+              GetObjectCommand,
+              PutObjectCommand,
             },
-            GetObjectCommand,
-            PutObjectCommand,
+            '../../../src/storage/utils/config.js': { default: () => ({}) },
           },
-          '../../../src/storage/utils/config.js': { default: () => ({}) },
-        },
-      );
+        );
 
-      const result = await writeAuditEntry({}, { bucket: 'b', org: 'o' }, 'repo', 'fid', {
-        timestamp: '5000',
-        users: '[{"email":"u@x.com"}]',
-        path: 'repo/doc.html',
-      });
+        result = await writeAuditEntry({}, { bucket: 'b', org: 'o' }, 'repo', 'fid', {
+          timestamp: '5000',
+          users: '[{"email":"u@x.com"}]',
+          path: 'repo/doc.html',
+        });
+      } finally {
+        globalThis.setTimeout = originalSetTimeout;
+      }
 
       assert.strictEqual(result.status, 500, 'persistent 412 must surface as 500 after 7 total attempts');
       assert.strictEqual(result.error, 'precondition failed');


### PR DESCRIPTION
After I merged #294 to main, the build on `main` failed in the test phase, even after a re-run. https://github.com/adobe/da-admin/actions/runs/28807439450/job/85428064849

This should make those tests fully deterministic to avoid this.

## What changed
Groups the three `writeAuditEntry` 412-retry tests in `test/storage/version/audit.test.js` under a nested `describe('412 retry backoff', ...)` with shared `beforeEach`/`afterEach` hooks that save/restore `globalThis.setTimeout`. Each test installs its own replacement (fire-immediately, or delay-capturing for the jitter-value assertions). No production code changed.

## Why
`writeAuditEntry`'s retry backoff (`src/storage/version/audit.js`) sleeps between attempts using real exponential-jitter `setTimeout` delays — worst case ~3050ms across 6 retries. One of these tests used real timers for that full retry chain, racing mocha's 2000ms default test timeout and intermittently failing CI. Stubbing `setTimeout` removes the real wait entirely, making the test deterministic. The other two tests in the same block had the same real-timer exposure (one already stubbed it independently, one didn't), so they're consolidated here rather than leaving three near-identical stub/restore blocks scattered through the file.