### PR TITLE
feat: derive source contentUrl from DA_CONTENT env var

### DIFF
--- a/src/helpers/source.js
+++ b/src/helpers/source.js
@@ -16,7 +16,7 @@ import normalizeCharset from '../utils/charset.js';
  * Builds a source response
  * @param {*} key
  */
-export function sourceRespObject(daCtx) {
+export function sourceRespObject(env, daCtx) {
   const {
     org, site, isFile, pathname, aemPathname,
   } = daCtx;
@@ -24,7 +24,7 @@ export function sourceRespObject(daCtx) {
   const obj = {
     source: {
       editUrl: `https://da.live/${isFile ? 'edit#/' : ''}${org}${pathname}`,
-      contentUrl: `https://content.da.live/${org}${pathname}`,
+      contentUrl: `${env.DA_CONTENT}/${org}${pathname}`,
     },
   };
 

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -17,6 +17,8 @@ export interface Env {
   S3_SECRET_ACCESS_KEY: string;
   IMS_ORIGIN: string;
   AEM_BUCKET_NAME: string;
+  // base URL for source content links (eg https://content.da.live)
+  DA_CONTENT: string;
   // shared secret used as authorization when invoking the collab service (eg for syncadmin)
   COLLAB_SHARED_SECRET: string;
   DA_OPS_IMS_ORG: string;

--- a/src/storage/object/put.js
+++ b/src/storage/object/put.js
@@ -66,7 +66,7 @@ export default async function putObject(env, daCtx, obj) {
     await client.send(command);
   }
 
-  const body = sourceRespObject(daCtx);
+  const body = sourceRespObject(env, daCtx);
   return {
     body: JSON.stringify(body), status, contentType: 'application/json', metadata, etag,
   };

--- a/test/helpers/source.test.js
+++ b/test/helpers/source.test.js
@@ -10,7 +10,7 @@
  * governing permissions and limitations under the License.
  */
 import assert from 'node:assert';
-import { putHelper } from '../../src/helpers/source.js';
+import { putHelper, sourceRespObject } from '../../src/helpers/source.js';
 
 import env from '../utils/mocks/env.js';
 
@@ -19,6 +19,44 @@ const daCtx = { org: 'cq', key: 'geometrixx/hello.html', propsKey: 'geometrixx/h
 const MOCK_URL = 'https://da.live/source/cq/geometrixx/hello';
 
 describe('Source helper', () => {
+  describe('sourceRespObject', () => {
+    it('builds contentUrl from env.DA_CONTENT', () => {
+      const obj = sourceRespObject(
+        { DA_CONTENT: 'https://stage-content.da.live' },
+        { org: 'cq', pathname: '/geometrixx/hello.html' },
+      );
+      assert.strictEqual(obj.source.contentUrl, 'https://stage-content.da.live/cq/geometrixx/hello.html');
+      assert.strictEqual(obj.source.editUrl, 'https://da.live/cq/geometrixx/hello.html');
+    });
+
+    it('uses production DA_CONTENT when provided', () => {
+      const obj = sourceRespObject(
+        { DA_CONTENT: 'https://content.da.live' },
+        { org: 'cq', pathname: '/geometrixx/hello.html' },
+      );
+      assert.strictEqual(obj.source.contentUrl, 'https://content.da.live/cq/geometrixx/hello.html');
+    });
+
+    it('adds aem urls when site is present', () => {
+      const obj = sourceRespObject(
+        { DA_CONTENT: 'https://content.da.live' },
+        {
+          org: 'cq', site: 'geometrixx', pathname: '/index.html', aemPathname: '/index',
+        },
+      );
+      assert.strictEqual(obj.aem.previewUrl, 'https://main--geometrixx--cq.aem.page/index');
+      assert.strictEqual(obj.aem.liveUrl, 'https://main--geometrixx--cq.aem.live/index');
+    });
+
+    it('uses edit#/ prefix for files', () => {
+      const obj = sourceRespObject(
+        { DA_CONTENT: 'https://content.da.live' },
+        { org: 'cq', isFile: true, pathname: '/geometrixx/hello.html' },
+      );
+      assert.strictEqual(obj.source.editUrl, 'https://da.live/edit#/cq/geometrixx/hello.html');
+    });
+  });
+
   describe('Put success', async () => {
     it('Returns null if no content type', async () => {
       const req = new Request(MOCK_URL);

--- a/test/it/it-tests.js
+++ b/test/it/it-tests.js
@@ -263,7 +263,7 @@ export default (ctx) => describe('Integration Tests: it tests', function () {
 
     let body = await resp.json();
     assert.strictEqual(body.source.editUrl, `https://da.live/edit#/${org}/${repo}/${key}`);
-    assert.strictEqual(body.source.contentUrl, `https://content.da.live/${org}/${repo}/${key}`);
+    assert.strictEqual(body.source.contentUrl, `https://stage-content.da.live/${org}/${repo}/${key}`);
     assert.strictEqual(body.aem.previewUrl, `https://main--${repo}--${org}.aem.page/${key}`);
     assert.strictEqual(body.aem.liveUrl, `https://main--${repo}--${org}.aem.live/${key}`);
 

--- a/test/utils/mocks/env.js
+++ b/test/utils/mocks/env.js
@@ -34,6 +34,7 @@ const DA_CONFIG = {
 };
 
 const env = {
+  DA_CONTENT: 'https://stage-content.da.live',
   S3_DEF_URL: 'https://s3.com',
   S3_ACCESS_KEY_ID: 'an-id',
   S3_SECRET_ACCESS_KEY: 'too-many-secrets',

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -25,6 +25,7 @@ r2_buckets = [
 ENVIRONMENT = "production"
 VERSION = "@@VERSION@@"
 DA_COLLAB = "https://collab.da.page"
+DA_CONTENT = "https://content.da.live"
 AEM_BUCKET_NAME = "aem-content"
 AEM_ADMIN_MEDIA_API = "https://admin.hlx.page/media"
 
@@ -50,6 +51,7 @@ r2_buckets = [
 ENVIRONMENT = "stage"
 VERSION = "@@VERSION@@-stage"
 DA_COLLAB = "https://collab.da.page"
+DA_CONTENT = "https://stage-content.da.live"
 AEM_BUCKET_NAME = "aem-content-stage"
 AEM_ADMIN_MEDIA_API = "https://admin.hlx.page/media"
 
@@ -75,6 +77,7 @@ r2_buckets = [
 ENVIRONMENT = "ci"
 VERSION = "@@VERSION@@-stage"
 DA_COLLAB = "https://collab.da.page"
+DA_CONTENT = "https://stage-content.da.live"
 AEM_BUCKET_NAME = "aem-content-stage"
 AEM_ADMIN_MEDIA_API = "https://admin.hlx.page/media"
 
@@ -101,6 +104,7 @@ r2_buckets = [
 ENVIRONMENT = "dev"
 VERSION="0.0.0-dev"
 DA_COLLAB = "http://localhost:4711"
+DA_CONTENT = "https://stage-content.da.live"
 AEM_BUCKET_NAME = "aem-content-stage"
 AEM_ADMIN_MEDIA_API = "https://admin.hlx.page/media"
 
@@ -126,6 +130,7 @@ r2_buckets = [
 ENVIRONMENT = "it"
 VERSION="0.0.0-it"
 DA_COLLAB = "http://localhost:4711"
+DA_CONTENT = "https://stage-content.da.live"
 AEM_BUCKET_NAME = "aem-content-local"
 AEM_ADMIN_MEDIA_API = "https://admin.hlx.page/media"
 


### PR DESCRIPTION
## What

The `contentUrl` returned in the source response was hardcoded to `https://content.da.live`. When the worker runs on stage/ci/dev/it, it should point to `https://stage-content.da.live`.

## Changes

- Add a `DA_CONTENT` var to every `wrangler.toml` environment:
  - `production` → `https://content.da.live`
  - `stage` / `ci` / `dev` / `it` → `https://stage-content.da.live`
- Thread `env` into `sourceRespObject(env, daCtx)` so `contentUrl` is built from `env.DA_CONTENT`.
- Add `DA_CONTENT` to the `Env` type and the test env mock.
- Add unit tests for `sourceRespObject`; update the IT assertion to `stage-content.da.live`.

Note: only `contentUrl` changed — `editUrl` still points to `da.live`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)